### PR TITLE
Replaces OAuth flow with direct password authentication

### DIFF
--- a/apps/patient-mobile/android/app/build.gradle
+++ b/apps/patient-mobile/android/app/build.gradle
@@ -84,8 +84,6 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
-        // Required by react-native-app-auth: must match the scheme in your redirect URI
-        manifestPlaceholders = [appAuthRedirectScheme: "com.cerios.patient"]
     }
     signingConfigs {
         debug {

--- a/apps/patient-mobile/package-lock.json
+++ b/apps/patient-mobile/package-lock.json
@@ -16,7 +16,6 @@
 				"axios": "^1.9.0",
 				"react": "19.2.3",
 				"react-native": "0.85.0",
-				"react-native-app-auth": "^8.1.0",
 				"react-native-dotenv": "^3.4.11",
 				"react-native-encrypted-storage": "^4.0.3",
 				"react-native-gesture-handler": "^2.26.0",
@@ -70,7 +69,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -1733,7 +1731,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
 			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -1949,7 +1946,6 @@
 			"integrity": "sha512-441WsVtRe4nGJ9OzA+QMU1+22lA6Q2hRWqqIMKD0wjEMLqcSfOZyu2UL9a/yRpL/dRpyUsU4n7AxqKfTKO/Csg==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@react-native-community/cli-clean": "20.1.0",
 				"@react-native-community/cli-config": "20.1.0",
@@ -2468,7 +2464,6 @@
 			"resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.85.0.tgz",
 			"integrity": "sha512-3L245HZo2F377BndO6WJD9qRZEnBOIG+uKcXvJirna8SzGxD7wvUjDJHHWvwZo4TXSP6aG/FOa/FAHhCYxjiBg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@react-native/js-polyfills": "0.85.0",
 				"@react-native/metro-babel-transformer": "0.85.0",
@@ -2586,7 +2581,6 @@
 			"resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
 			"integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@react-navigation/core": "^7.17.2",
 				"escape-string-regexp": "^4.0.0",
@@ -3106,7 +3100,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.12",
 				"caniuse-lite": "^1.0.30001782",
@@ -6037,7 +6030,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
 			"integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6096,7 +6088,6 @@
 			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.85.0.tgz",
 			"integrity": "sha512-z2ltUAS9xzdL4HQeG7wpsYMv2o35R4D8qZwbXu0SbeamZ4+ZIBxc84Ay4Vb6fRExBpsT06aZFV+W030W9JxDFQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@react-native/assets-registry": "0.85.0",
 				"@react-native/codegen": "0.85.0",
@@ -6150,25 +6141,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/react-native-app-auth": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/react-native-app-auth/-/react-native-app-auth-8.1.0.tgz",
-			"integrity": "sha512-PNX+iNMO6Ix3YBc5oKOEugCyPzAZ3MjKPk0dhWAzDnS1cPld7RPcxOzIjEd7+FYF1VGlGxhgOpFz+pOyRDJGdQ==",
-			"license": "MIT",
-			"dependencies": {
-				"invariant": "2.2.4",
-				"react-native-base64": "0.0.2"
-			},
-			"peerDependencies": {
-				"react-native": ">=0.63.0"
-			}
-		},
-		"node_modules/react-native-base64": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/react-native-base64/-/react-native-base64-0.0.2.tgz",
-			"integrity": "sha512-Fu/J1a2y0X22EJDWqJR2oEa1fpP4gTFjYxk8ElJdt1Yak3HOXmFJ7EohLVHU2DaQkgmKfw8qb7u/48gpzveRbg==",
-			"license": "MIT"
 		},
 		"node_modules/react-native-dotenv": {
 			"version": "3.4.11",
@@ -6260,7 +6232,6 @@
 			"resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.7.0.tgz",
 			"integrity": "sha512-/9/MtQz8ODphjsLdZ+GZAIcC/RtoqW9EeShf7Uvnfgm/pzYrJ75y3PV/J1wuAV1T5Dye5ygq4EAW20RoBq0ABQ==",
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"react": "*",
 				"react-native": "*"
@@ -6271,7 +6242,6 @@
 			"resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.24.0.tgz",
 			"integrity": "sha512-SyoiGaDofiyGPFrUkn1oGsAzkRuX1JUvTD9YQQK3G1JGQ5VWkvHgYSsc1K9OrLsDQxN7NmV71O0sHCAh8cBetA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"react-freeze": "^1.0.0",
 				"warn-once": "^0.1.0"
@@ -6286,7 +6256,6 @@
 			"resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.8.1.tgz",
 			"integrity": "sha512-oWP/lStsAHU6oYCaWDXrda/wOHVdhusQJz1e6x9gPnXdFf4ndNDAOtWCmk2zGrAnlapfyA3rM6PCQq94mPg9cw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/plugin-transform-arrow-functions": "^7.27.1",
 				"@babel/plugin-transform-class-properties": "^7.27.1",
@@ -7112,7 +7081,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7165,9 +7133,8 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/apps/patient-mobile/package.json
+++ b/apps/patient-mobile/package.json
@@ -16,7 +16,6 @@
 		"axios": "^1.9.0",
 		"react": "19.2.3",
 		"react-native": "0.85.0",
-		"react-native-app-auth": "^8.1.0",
 		"react-native-dotenv": "^3.4.11",
 		"react-native-encrypted-storage": "^4.0.3",
 		"react-native-gesture-handler": "^2.26.0",

--- a/apps/patient-mobile/src/auth/AuthContext.tsx
+++ b/apps/patient-mobile/src/auth/AuthContext.tsx
@@ -3,7 +3,14 @@ import { AppState, type AppStateStatus } from "react-native";
 
 import api, { updateCachedToken } from "../api/client";
 
-import { signIn, signOut, getStoredTokens, refreshTokens, isTokenExpiringSoon, parseAccessToken } from "./keycloak";
+import {
+	signInWithPassword,
+	signOut,
+	getStoredTokens,
+	refreshTokens,
+	isTokenExpiringSoon,
+	parseAccessToken,
+} from "./keycloak";
 
 interface AuthUser {
 	sub: string;
@@ -15,7 +22,7 @@ interface AuthUser {
 interface AuthContextValue {
 	user: AuthUser | null;
 	isLoading: boolean;
-	login: () => Promise<void>;
+	login: (username: string, password: string) => Promise<void>;
 	logout: () => Promise<void>;
 }
 
@@ -92,20 +99,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }): React
 		return (): void => subscription.remove();
 	}, [applyTokens]);
 
-	const login = useCallback(async () => {
-		const result = await signIn();
-		applyTokens(result.accessToken);
-		// Sync Keycloak identity to the patient DB — fire-and-forget, idempotent on the server
-		const claims = parseAccessToken(result.accessToken) as Record<string, string>;
-		api
-			.post("/auth/sync", {
-				keycloakId: claims.sub,
-				email: claims.email,
-				firstName: claims.given_name,
-				lastName: claims.family_name,
-			})
-			.catch(() => undefined);
-	}, [applyTokens]);
+	const login = useCallback(
+		async (username: string, password: string) => {
+			const result = await signInWithPassword(username, password);
+			applyTokens(result.accessToken);
+			// Sync Keycloak identity to the patient DB — fire-and-forget, idempotent on the server
+			const claims = parseAccessToken(result.accessToken) as Record<string, string>;
+			api
+				.post("/auth/sync", {
+					keycloakId: claims.sub,
+					email: claims.email,
+					firstName: claims.given_name,
+					lastName: claims.family_name,
+				})
+				.catch(() => undefined);
+		},
+		[applyTokens]
+	);
 
 	const logout = useCallback(async () => {
 		await signOut();

--- a/apps/patient-mobile/src/auth/keycloak.ts
+++ b/apps/patient-mobile/src/auth/keycloak.ts
@@ -1,11 +1,15 @@
 import { KEYCLOAK_URL, KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID } from "@env";
-import { authorize, logout as appAuthLogout, refresh, revoke, type AuthorizeResult } from "react-native-app-auth";
 import EncryptedStorage from "react-native-encrypted-storage";
 
 const STORAGE_KEY = "cerios_auth_tokens";
 
 const realmBaseUrl = `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}`;
 const oidcBaseUrl = `${realmBaseUrl}/protocol/openid-connect`;
+const tokenEndpoint = `${oidcBaseUrl}/token`;
+const logoutEndpoint = `${oidcBaseUrl}/logout`;
+const revocationEndpoint = `${oidcBaseUrl}/revoke`;
+
+const SCOPES = "openid profile email roles";
 
 export interface StoredTokens {
 	accessToken: string;
@@ -14,59 +18,118 @@ export interface StoredTokens {
 	idToken: string;
 }
 
-const config = {
-	issuer: realmBaseUrl,
-	// Avoid relying on discovery metadata hostnames (often localhost in local
-	// Docker setups), which are unreachable from Android emulators/devices.
-	serviceConfiguration: {
-		authorizationEndpoint: `${oidcBaseUrl}/auth`,
-		tokenEndpoint: `${oidcBaseUrl}/token`,
-		revocationEndpoint: `${oidcBaseUrl}/revoke`,
-		endSessionEndpoint: `${oidcBaseUrl}/logout`,
-	},
-	clientId: KEYCLOAK_CLIENT_ID,
-	redirectUrl: "com.cerios.patient://oauth2redirect",
-	scopes: ["openid", "profile", "email", "roles"],
-	dangerouslyAllowInsecureHttpRequests: KEYCLOAK_URL.startsWith("http://"),
-	additionalParameters: {},
-};
+interface KeycloakTokenResponse {
+	access_token: string;
+	refresh_token: string;
+	id_token?: string;
+	expires_in: number;
+	token_type: string;
+}
 
-export async function signIn(): Promise<AuthorizeResult> {
-	const result = await authorize(config);
-	await storeTokens({
-		accessToken: result.accessToken,
-		refreshToken: result.refreshToken,
-		accessTokenExpirationDate: result.accessTokenExpirationDate,
-		idToken: result.idToken,
+interface KeycloakErrorResponse {
+	error?: string;
+	error_description?: string;
+}
+
+/** Thrown by `signInWithPassword` for any non-2xx response from the token endpoint. */
+export class AuthError extends Error {
+	readonly code: string;
+	constructor(code: string, message: string) {
+		super(message);
+		this.code = code;
+		this.name = "AuthError";
+	}
+}
+
+function encodeForm(params: Record<string, string>): string {
+	return Object.entries(params)
+		.map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+		.join("&");
+}
+
+async function postForm<T>(url: string, params: Record<string, string>): Promise<T> {
+	const response = await fetch(url, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/x-www-form-urlencoded",
+			Accept: "application/json",
+		},
+		body: encodeForm(params),
 	});
-	return result;
+	const text = await response.text();
+	const data = text ? (JSON.parse(text) as T & KeycloakErrorResponse) : ({} as T & KeycloakErrorResponse);
+	if (!response.ok) {
+		const err = data as KeycloakErrorResponse;
+		throw new AuthError(
+			err.error ?? `http_${response.status}`,
+			err.error_description ?? `Request failed (${response.status})`
+		);
+	}
+	return data;
+}
+
+function toStoredTokens(result: KeycloakTokenResponse, previous?: StoredTokens | null): StoredTokens {
+	const expiresAt = new Date(Date.now() + result.expires_in * 1000).toISOString();
+	return {
+		accessToken: result.access_token,
+		refreshToken: result.refresh_token,
+		accessTokenExpirationDate: expiresAt,
+		idToken: result.id_token ?? previous?.idToken ?? "",
+	};
+}
+
+export async function signInWithPassword(username: string, password: string): Promise<StoredTokens> {
+	let result: KeycloakTokenResponse;
+	try {
+		result = await postForm<KeycloakTokenResponse>(tokenEndpoint, {
+			grant_type: "password",
+			client_id: KEYCLOAK_CLIENT_ID,
+			username,
+			password,
+			scope: SCOPES,
+		});
+	} catch (e) {
+		if (e instanceof AuthError) {
+			if (e.code === "invalid_grant") {
+				throw new AuthError(e.code, "Invalid username or password.");
+			}
+			throw e;
+		}
+		throw new AuthError("network_error", "Could not reach the server. Check your connection and try again.");
+	}
+	const stored = toStoredTokens(result);
+	await storeTokens(stored);
+	return stored;
 }
 
 export async function refreshTokens(): Promise<StoredTokens | null> {
 	const stored = await getStoredTokens();
 	if (!stored?.refreshToken) return null;
 
-	const result = await refresh(config, { refreshToken: stored.refreshToken });
-	const updated: StoredTokens = {
-		accessToken: result.accessToken,
-		refreshToken: result.refreshToken ?? stored.refreshToken,
-		accessTokenExpirationDate: result.accessTokenExpirationDate,
-		idToken: result.idToken ?? stored.idToken,
-	};
+	const result = await postForm<KeycloakTokenResponse>(tokenEndpoint, {
+		grant_type: "refresh_token",
+		client_id: KEYCLOAK_CLIENT_ID,
+		refresh_token: stored.refreshToken,
+	});
+	const updated = toStoredTokens(result, stored);
 	await storeTokens(updated);
 	return updated;
 }
 
 export async function signOut(): Promise<void> {
 	const stored = await getStoredTokens();
-	if (stored?.idToken) {
-		await appAuthLogout(config, {
-			idToken: stored.idToken,
-			postLogoutRedirectUrl: config.redirectUrl,
+	if (stored?.refreshToken) {
+		// End the SSO session server-side
+		await postForm(logoutEndpoint, {
+			client_id: KEYCLOAK_CLIENT_ID,
+			refresh_token: stored.refreshToken,
 		}).catch(() => undefined);
-	}
-	if (stored?.accessToken) {
-		await revoke(config, { tokenToRevoke: stored.accessToken, sendClientId: true }).catch(() => undefined);
+		// Best-effort revoke of the refresh token
+		await postForm(revocationEndpoint, {
+			client_id: KEYCLOAK_CLIENT_ID,
+			token: stored.refreshToken,
+			token_type_hint: "refresh_token",
+		}).catch(() => undefined);
 	}
 	await clearTokens();
 }

--- a/apps/patient-mobile/src/screens/LoginScreen.tsx
+++ b/apps/patient-mobile/src/screens/LoginScreen.tsx
@@ -1,23 +1,41 @@
 import React, { useState } from "react";
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { ActivityIndicator, Linking, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
+import { KEYCLOAK_URL, KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID } from "@env";
 
 import { useAuth } from "../auth/AuthContext";
 
+const realmBaseUrl = `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}`;
+const forgotPasswordUrl = `${realmBaseUrl}/login-actions/reset-credentials?client_id=${encodeURIComponent(KEYCLOAK_CLIENT_ID)}`;
+const registerUrl = `${realmBaseUrl}/protocol/openid-connect/registrations?client_id=${encodeURIComponent(KEYCLOAK_CLIENT_ID)}&response_type=code&scope=openid&redirect_uri=${encodeURIComponent("com.cerios.patient://oauth2redirect")}`;
+
 export default function LoginScreen(): React.JSX.Element {
 	const { login } = useAuth();
+	const [username, setUsername] = useState("");
+	const [password, setPassword] = useState("");
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState("");
 
 	const handleLogin = async (): Promise<void> => {
+		if (!username.trim() || !password) {
+			setError("Please enter your username and password.");
+			return;
+		}
 		setLoading(true);
 		setError("");
 		try {
-			await login();
-		} catch {
-			setError("Login failed. Please try again.");
+			await login(username.trim(), password);
+		} catch (e) {
+			const message = e instanceof Error && e.message ? e.message : "Login failed. Please try again.";
+			setError(message);
 		} finally {
 			setLoading(false);
 		}
+	};
+
+	const openExternal = (url: string): void => {
+		void Linking.openURL(url).catch(() => {
+			setError("Could not open the browser.");
+		});
 	};
 
 	return (
@@ -31,21 +49,71 @@ export default function LoginScreen(): React.JSX.Element {
 			<View style={styles.card}>
 				{error ? <Text style={styles.error}>{error}</Text> : null}
 
+				<TextInput
+					style={styles.input}
+					placeholder="Username or email"
+					placeholderTextColor="#9CA3AF"
+					value={username}
+					onChangeText={setUsername}
+					autoCapitalize="none"
+					autoCorrect={false}
+					keyboardType="email-address"
+					textContentType="username"
+					editable={!loading}
+					testID="login-username"
+					accessibilityLabel="Username"
+					returnKeyType="next"
+				/>
+
+				<TextInput
+					style={styles.input}
+					placeholder="Password"
+					placeholderTextColor="#9CA3AF"
+					value={password}
+					onChangeText={setPassword}
+					secureTextEntry
+					autoCapitalize="none"
+					autoCorrect={false}
+					textContentType="password"
+					editable={!loading}
+					testID="login-password"
+					accessibilityLabel="Password"
+					returnKeyType="go"
+					onSubmitEditing={(): void => {
+						void handleLogin();
+					}}
+				/>
+
 				<TouchableOpacity
 					style={[styles.button, loading && styles.buttonDisabled]}
 					onPress={(): void => {
 						void handleLogin();
 					}}
 					disabled={loading}
+					testID="login-submit"
+					accessibilityLabel="Sign in"
 				>
-					{loading ? (
-						<ActivityIndicator color="#ffffff" />
-					) : (
-						<Text style={styles.buttonText}>Sign in with Clinic Account</Text>
-					)}
+					{loading ? <ActivityIndicator color="#ffffff" /> : <Text style={styles.buttonText}>Sign in</Text>}
 				</TouchableOpacity>
 
-				<Text style={styles.hint}>Don't have an account? Register at the patient web portal.</Text>
+				<View style={styles.linksRow}>
+					<TouchableOpacity
+						onPress={(): void => openExternal(forgotPasswordUrl)}
+						disabled={loading}
+						testID="login-forgot-password"
+						accessibilityLabel="Forgot password"
+					>
+						<Text style={styles.link}>Forgot password?</Text>
+					</TouchableOpacity>
+					<TouchableOpacity
+						onPress={(): void => openExternal(registerUrl)}
+						disabled={loading}
+						testID="login-register"
+						accessibilityLabel="Create account"
+					>
+						<Text style={styles.link}>Create account</Text>
+					</TouchableOpacity>
+				</View>
 			</View>
 		</View>
 	);
@@ -86,11 +154,23 @@ const styles = StyleSheet.create({
 		shadowRadius: 8,
 		elevation: 3,
 	},
+	input: {
+		borderWidth: 1,
+		borderColor: "#E5E7EB",
+		borderRadius: 10,
+		paddingHorizontal: 14,
+		paddingVertical: 12,
+		fontSize: 15,
+		color: "#1A2238",
+		backgroundColor: "#ffffff",
+		marginBottom: 12,
+	},
 	button: {
 		backgroundColor: "#E85A28",
 		borderRadius: 10,
 		paddingVertical: 14,
 		alignItems: "center",
+		marginTop: 4,
 		marginBottom: 16,
 	},
 	buttonDisabled: {
@@ -107,9 +187,14 @@ const styles = StyleSheet.create({
 		fontSize: 14,
 		textAlign: "center",
 	},
-	hint: {
+	linksRow: {
+		flexDirection: "row",
+		justifyContent: "space-between",
+		marginTop: 4,
+	},
+	link: {
+		color: "#1A2238",
 		fontSize: 13,
-		color: "#9CA3AF",
-		textAlign: "center",
+		fontWeight: "500",
 	},
 });

--- a/apps/patient-mobile/src/screens/LoginScreen.tsx
+++ b/apps/patient-mobile/src/screens/LoginScreen.tsx
@@ -1,6 +1,6 @@
+import { KEYCLOAK_URL, KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID } from "@env";
 import React, { useState } from "react";
 import { ActivityIndicator, Linking, StyleSheet, Text, TextInput, TouchableOpacity, View } from "react-native";
-import { KEYCLOAK_URL, KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID } from "@env";
 
 import { useAuth } from "../auth/AuthContext";
 

--- a/infra/keycloak/clinic-realm.json
+++ b/infra/keycloak/clinic-realm.json
@@ -154,7 +154,7 @@
 			"enabled": true,
 			"publicClient": true,
 			"standardFlowEnabled": true,
-			"directAccessGrantsEnabled": false,
+			"directAccessGrantsEnabled": true,
 			"redirectUris": ["com.cerios.patient://oauth2redirect"],
 			"webOrigins": [],
 			"attributes": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,9 +705,6 @@ importers:
       react-native:
         specifier: 0.85.0
         version: 0.85.0(@babel/core@7.29.0)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-      react-native-app-auth:
-        specifier: ^8.1.0
-        version: 8.1.0(react-native@0.85.0(@babel/core@7.29.0)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))
       react-native-dotenv:
         specifier: ^3.4.11
         version: 3.4.11(@babel/runtime@7.29.2)
@@ -4980,14 +4977,6 @@ packages:
 
   react-is@19.2.5:
     resolution: {integrity: sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==}
-
-  react-native-app-auth@8.1.0:
-    resolution: {integrity: sha512-PNX+iNMO6Ix3YBc5oKOEugCyPzAZ3MjKPk0dhWAzDnS1cPld7RPcxOzIjEd7+FYF1VGlGxhgOpFz+pOyRDJGdQ==}
-    peerDependencies:
-      react-native: '>=0.63.0'
-
-  react-native-base64@0.0.2:
-    resolution: {integrity: sha512-Fu/J1a2y0X22EJDWqJR2oEa1fpP4gTFjYxk8ElJdt1Yak3HOXmFJ7EohLVHU2DaQkgmKfw8qb7u/48gpzveRbg==}
 
   react-native-dotenv@3.4.11:
     resolution: {integrity: sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg==}
@@ -10139,14 +10128,6 @@ snapshots:
   react-is@18.3.1: {}
 
   react-is@19.2.5: {}
-
-  react-native-app-auth@8.1.0(react-native@0.85.0(@babel/core@7.29.0)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)):
-    dependencies:
-      invariant: 2.2.4
-      react-native: 0.85.0(@babel/core@7.29.0)(@react-native-community/cli@20.1.0(typescript@5.9.3))(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-      react-native-base64: 0.0.2
-
-  react-native-base64@0.0.2: {}
 
   react-native-dotenv@3.4.11(@babel/runtime@7.29.2):
     dependencies:


### PR DESCRIPTION
Removes the react-native-app-auth dependency in favor of direct Resource Owner Password Credentials (ROPC) flow for the mobile patient app.

Eliminates the browser-based OAuth redirect flow, which was problematic for mobile users, and replaces it with a traditional username/password login form. This simplifies the user experience by keeping authentication entirely within the app.

Implements custom token management functions that call Keycloak's token endpoint directly using fetch, providing better error handling and control over the authentication flow.

Adds input fields for username and password on the login screen, along with links to forgot password and account registration flows that open in an external browser.

Enables direct access grants for the patient mobile client in the Keycloak realm configuration to support password-based authentication.