### PR TITLE
Adds comprehensive Swagger/OpenAPI documentation

### DIFF
--- a/apps/api-admin/src/admin/admin.controller.ts
+++ b/apps/api-admin/src/admin/admin.controller.ts
@@ -1,4 +1,10 @@
 import {
+	AssistantCoreResponseDto,
+	DoctorCoreResponseDto,
+	MessageResponseDto,
+	UserCoreResponseDto,
+} from "@clinic/api-common";
+import {
 	Controller,
 	Get,
 	Post,
@@ -11,7 +17,15 @@ import {
 	NotFoundException,
 	ConflictException,
 } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import {
+	ApiBearerAuth,
+	ApiCreatedResponse,
+	ApiOkResponse,
+	ApiOperation,
+	ApiProperty,
+	ApiPropertyOptional,
+	ApiTags,
+} from "@nestjs/swagger";
 import { Prisma } from "@prisma/client";
 import { IsString, IsEmail, IsNotEmpty, IsOptional, MinLength } from "class-validator";
 
@@ -23,33 +37,87 @@ import { PrismaService } from "../prisma/prisma.service";
 import { KeycloakAdminService } from "./keycloak-admin.service";
 
 class CreateDoctorDto {
-	@IsEmail() email: string;
-	@IsString() @IsNotEmpty() firstName: string;
-	@IsString() @IsNotEmpty() lastName: string;
-	@IsOptional() @IsString() specialization?: string;
-	@IsOptional() @IsString() licenseNumber?: string;
-	@IsString() @IsNotEmpty() @MinLength(8) password: string;
+	@ApiProperty({ format: "email", example: "doctor@example.com" })
+	@IsEmail()
+	email: string;
+	@ApiProperty({ example: "Alice" })
+	@IsString()
+	@IsNotEmpty()
+	firstName: string;
+	@ApiProperty({ example: "Morgan" })
+	@IsString()
+	@IsNotEmpty()
+	lastName: string;
+	@ApiPropertyOptional({ example: "Cardiology" })
+	@IsOptional()
+	@IsString()
+	specialization?: string;
+	@ApiPropertyOptional({ example: "MED-12345" })
+	@IsOptional()
+	@IsString()
+	licenseNumber?: string;
+	@ApiProperty({ minLength: 8, example: "StrongPass123", writeOnly: true })
+	@IsString()
+	@IsNotEmpty()
+	@MinLength(8)
+	password: string;
 }
 
 class UpdateDoctorDto {
-	@IsOptional() @IsString() firstName?: string;
-	@IsOptional() @IsString() lastName?: string;
-	@IsOptional() @IsString() specialization?: string;
-	@IsOptional() @IsString() licenseNumber?: string;
+	@ApiPropertyOptional({ example: "Alice" })
+	@IsOptional()
+	@IsString()
+	firstName?: string;
+	@ApiPropertyOptional({ example: "Morgan" })
+	@IsOptional()
+	@IsString()
+	lastName?: string;
+	@ApiPropertyOptional({ example: "Cardiology" })
+	@IsOptional()
+	@IsString()
+	specialization?: string;
+	@ApiPropertyOptional({ example: "MED-12345" })
+	@IsOptional()
+	@IsString()
+	licenseNumber?: string;
 }
 
 class CreateAssistantDto {
-	@IsEmail() email: string;
-	@IsString() @IsNotEmpty() firstName: string;
-	@IsString() @IsNotEmpty() lastName: string;
-	@IsOptional() @IsString() department?: string;
-	@IsString() @IsNotEmpty() @MinLength(8) password: string;
+	@ApiProperty({ format: "email", example: "assistant@example.com" })
+	@IsEmail()
+	email: string;
+	@ApiProperty({ example: "Jamie" })
+	@IsString()
+	@IsNotEmpty()
+	firstName: string;
+	@ApiProperty({ example: "Lee" })
+	@IsString()
+	@IsNotEmpty()
+	lastName: string;
+	@ApiPropertyOptional({ example: "Front Desk" })
+	@IsOptional()
+	@IsString()
+	department?: string;
+	@ApiProperty({ minLength: 8, example: "StrongPass123", writeOnly: true })
+	@IsString()
+	@IsNotEmpty()
+	@MinLength(8)
+	password: string;
 }
 
 class UpdateAssistantDto {
-	@IsOptional() @IsString() firstName?: string;
-	@IsOptional() @IsString() lastName?: string;
-	@IsOptional() @IsString() department?: string;
+	@ApiPropertyOptional({ example: "Jamie" })
+	@IsOptional()
+	@IsString()
+	firstName?: string;
+	@ApiPropertyOptional({ example: "Lee" })
+	@IsOptional()
+	@IsString()
+	lastName?: string;
+	@ApiPropertyOptional({ example: "Front Desk" })
+	@IsOptional()
+	@IsString()
+	department?: string;
 }
 
 type UserWithRelations = Prisma.UserGetPayload<{ include: { doctor: true; assistant: true } }>;
@@ -57,6 +125,65 @@ type UserWithDoctor = Prisma.UserGetPayload<{ include: { doctor: true } }>;
 type DoctorWithUser = Prisma.DoctorGetPayload<{ include: { user: true } }>;
 type UserWithAssistant = Prisma.UserGetPayload<{ include: { assistant: true } }>;
 type AssistantWithUser = Prisma.AssistantGetPayload<{ include: { user: true } }>;
+
+class AdminUserWithRelationsResponseDto extends UserCoreResponseDto {
+	@ApiPropertyOptional({ type: () => DoctorCoreResponseDto, nullable: true })
+	doctor?: DoctorCoreResponseDto | null;
+
+	@ApiPropertyOptional({ type: () => AssistantCoreResponseDto, nullable: true })
+	assistant?: AssistantCoreResponseDto | null;
+}
+
+class AdminUserWithDoctorResponseDto extends UserCoreResponseDto {
+	@ApiProperty({ type: () => DoctorCoreResponseDto })
+	doctor!: DoctorCoreResponseDto;
+}
+
+class AdminDoctorWithUserResponseDto extends DoctorCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class AdminUserWithAssistantResponseDto extends UserCoreResponseDto {
+	@ApiProperty({ type: () => AssistantCoreResponseDto })
+	assistant!: AssistantCoreResponseDto;
+}
+
+class AdminAssistantWithUserResponseDto extends AssistantCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class AdminUsersListResponseDto {
+	@ApiProperty({ type: () => AdminUserWithRelationsResponseDto, isArray: true })
+	data!: AdminUserWithRelationsResponseDto[];
+}
+
+class AdminDoctorCreateResponseDto {
+	@ApiProperty({ type: () => AdminUserWithDoctorResponseDto })
+	data!: AdminUserWithDoctorResponseDto;
+
+	@ApiProperty({ example: "Doctor created successfully" })
+	message!: string;
+}
+
+class AdminDoctorUpdateResponseDto {
+	@ApiProperty({ type: () => AdminDoctorWithUserResponseDto })
+	data!: AdminDoctorWithUserResponseDto;
+}
+
+class AdminAssistantCreateResponseDto {
+	@ApiProperty({ type: () => AdminUserWithAssistantResponseDto })
+	data!: AdminUserWithAssistantResponseDto;
+
+	@ApiProperty({ example: "Assistant created successfully" })
+	message!: string;
+}
+
+class AdminAssistantUpdateResponseDto {
+	@ApiProperty({ type: () => AdminAssistantWithUserResponseDto })
+	data!: AdminAssistantWithUserResponseDto;
+}
 
 @ApiTags("admin")
 @ApiBearerAuth()
@@ -71,6 +198,7 @@ export class AdminController {
 
 	@Get("users")
 	@ApiOperation({ summary: "[Admin] List all doctors and assistants" })
+	@ApiOkResponse({ type: AdminUsersListResponseDto })
 	async listUsers(): Promise<{ data: UserWithRelations[] }> {
 		const users = await this.prisma.user.findMany({
 			where: { role: { in: ["doctor", "assistant"] }, deletedAt: null },
@@ -82,6 +210,7 @@ export class AdminController {
 
 	@Post("doctors")
 	@ApiOperation({ summary: "[Admin] Create a new doctor account" })
+	@ApiCreatedResponse({ type: AdminDoctorCreateResponseDto })
 	async createDoctor(@Body() dto: CreateDoctorDto): Promise<{ data: UserWithDoctor; message: string }> {
 		const existing = await this.prisma.user.findUnique({ where: { email: dto.email } });
 		if (existing) throw new ConflictException("Email already in use");
@@ -120,6 +249,7 @@ export class AdminController {
 
 	@Put("doctors/:id")
 	@ApiOperation({ summary: "[Admin] Update a doctor" })
+	@ApiOkResponse({ type: AdminDoctorUpdateResponseDto })
 	async updateDoctor(
 		@Param("id", ParseUUIDPipe) id: string,
 		@Body() dto: UpdateDoctorDto
@@ -156,6 +286,7 @@ export class AdminController {
 
 	@Delete("doctors/:id")
 	@ApiOperation({ summary: "[Admin] Soft-delete a doctor (disables Keycloak account)" })
+	@ApiOkResponse({ type: MessageResponseDto })
 	async deleteDoctor(@Param("id", ParseUUIDPipe) id: string): Promise<{ message: string }> {
 		const doctor = await this.prisma.doctor.findUnique({
 			where: { id },
@@ -173,6 +304,7 @@ export class AdminController {
 
 	@Post("assistants")
 	@ApiOperation({ summary: "[Admin] Create a new assistant account" })
+	@ApiCreatedResponse({ type: AdminAssistantCreateResponseDto })
 	async createAssistant(@Body() dto: CreateAssistantDto): Promise<{ data: UserWithAssistant; message: string }> {
 		const existing = await this.prisma.user.findUnique({ where: { email: dto.email } });
 		if (existing) throw new ConflictException("Email already in use");
@@ -208,6 +340,7 @@ export class AdminController {
 
 	@Put("assistants/:id")
 	@ApiOperation({ summary: "[Admin] Update an assistant" })
+	@ApiOkResponse({ type: AdminAssistantUpdateResponseDto })
 	async updateAssistant(
 		@Param("id", ParseUUIDPipe) id: string,
 		@Body() dto: UpdateAssistantDto
@@ -243,6 +376,7 @@ export class AdminController {
 
 	@Delete("assistants/:id")
 	@ApiOperation({ summary: "[Admin] Soft-delete an assistant (disables Keycloak account)" })
+	@ApiOkResponse({ type: MessageResponseDto })
 	async deleteAssistant(@Param("id", ParseUUIDPipe) id: string): Promise<{ message: string }> {
 		const assistant = await this.prisma.assistant.findUnique({
 			where: { id },

--- a/apps/api-admin/src/feature-toggles/feature-toggles.controller.ts
+++ b/apps/api-admin/src/feature-toggles/feature-toggles.controller.ts
@@ -1,6 +1,14 @@
+import { FeatureToggleDetailResponseDto, FeatureToggleListResponseDto, MessageResponseDto } from "@clinic/api-common";
 import { Controller, Get, Put, Param, Body, UseGuards, Post } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
-import { Prisma } from "@prisma/client";
+import {
+	ApiBearerAuth,
+	ApiCreatedResponse,
+	ApiOkResponse,
+	ApiOperation,
+	ApiPropertyOptional,
+	ApiTags,
+} from "@nestjs/swagger";
+import { type FeatureToggle, Prisma } from "@prisma/client";
 import { IsBoolean, IsOptional, IsObject } from "class-validator";
 
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
@@ -10,8 +18,14 @@ import { RolesGuard } from "../auth/roles.guard";
 import { FeatureTogglesService } from "./feature-toggles.service";
 
 class UpdateToggleDto {
-	@IsOptional() @IsBoolean() enabled?: boolean;
-	@IsOptional() @IsObject() config?: Prisma.InputJsonValue;
+	@ApiPropertyOptional({ example: true })
+	@IsOptional()
+	@IsBoolean()
+	enabled?: boolean;
+	@ApiPropertyOptional({ type: Object, additionalProperties: true, example: { rolloutPercentage: 50 } })
+	@IsOptional()
+	@IsObject()
+	config?: Prisma.InputJsonValue;
 }
 
 @ApiTags("feature-toggles")
@@ -24,30 +38,31 @@ export class FeatureTogglesController {
 
 	@Get()
 	@ApiOperation({ summary: "List all feature toggles" })
-	async list(): Promise<{ data: Awaited<ReturnType<FeatureTogglesService["findAll"]>> }> {
+	@ApiOkResponse({ type: FeatureToggleListResponseDto })
+	async list(): Promise<{ data: FeatureToggle[] }> {
 		const toggles = await this.service.findAll();
 		return { data: toggles };
 	}
 
 	@Get(":key")
 	@ApiOperation({ summary: "Get a feature toggle by key" })
-	async get(@Param("key") key: string): Promise<{ data: Awaited<ReturnType<FeatureTogglesService["findByKey"]>> }> {
+	@ApiOkResponse({ type: FeatureToggleDetailResponseDto })
+	async get(@Param("key") key: string): Promise<{ data: FeatureToggle }> {
 		const toggle = await this.service.findByKey(key);
 		return { data: toggle };
 	}
 
 	@Put(":key")
 	@ApiOperation({ summary: "Update a feature toggle" })
-	async update(
-		@Param("key") key: string,
-		@Body() dto: UpdateToggleDto
-	): Promise<{ data: Awaited<ReturnType<FeatureTogglesService["upsert"]>> }> {
+	@ApiOkResponse({ type: FeatureToggleDetailResponseDto })
+	async update(@Param("key") key: string, @Body() dto: UpdateToggleDto): Promise<{ data: FeatureToggle }> {
 		const toggle = await this.service.upsert(key, dto);
 		return { data: toggle };
 	}
 
 	@Post("seed")
 	@ApiOperation({ summary: "Seed default feature toggles" })
+	@ApiCreatedResponse({ type: MessageResponseDto })
 	async seed(): Promise<{ message: string }> {
 		await this.service.seed();
 		return { message: "Feature toggles seeded" };

--- a/apps/api-admin/src/health/health.controller.ts
+++ b/apps/api-admin/src/health/health.controller.ts
@@ -1,14 +1,18 @@
-import { Public } from "@clinic/api-common";
+import { HealthResponseDto, Public } from "@clinic/api-common";
 import { Controller, Get, ServiceUnavailableException } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 
 import { PrismaService } from "../prisma/prisma.service";
 
 @Public()
+@ApiTags("health")
 @Controller("health")
 export class HealthController {
 	constructor(private readonly prisma: PrismaService) {}
 
 	@Get()
+	@ApiOperation({ summary: "Liveness probe" })
+	@ApiOkResponse({ type: HealthResponseDto })
 	liveness(): { status: string; service: string; timestamp: string } {
 		return {
 			status: "ok",
@@ -18,6 +22,8 @@ export class HealthController {
 	}
 
 	@Get("ready")
+	@ApiOperation({ summary: "Readiness probe" })
+	@ApiOkResponse({ type: HealthResponseDto })
 	async readiness(): Promise<{ status: string; service: string; timestamp: string }> {
 		try {
 			await this.prisma.$queryRaw`SELECT 1`;

--- a/apps/api-assistant/src/appointments/appointments.controller.ts
+++ b/apps/api-assistant/src/appointments/appointments.controller.ts
@@ -15,7 +15,16 @@ import {
 	BadRequestException,
 	ConflictException,
 } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from "@nestjs/swagger";
+import {
+	ApiBearerAuth,
+	ApiCreatedResponse,
+	ApiOkResponse,
+	ApiOperation,
+	ApiProperty,
+	ApiPropertyOptional,
+	ApiQuery,
+	ApiTags,
+} from "@nestjs/swagger";
 import {
 	Prisma,
 	Appointment,
@@ -52,18 +61,274 @@ type EnrichedStatusChange = AppointmentStatusChange & {
 };
 
 class CreateAppointmentDto {
-	@IsUUID() patientId: string;
-	@IsUUID() doctorId: string;
-	@IsDateString() scheduledAt: string;
-	@IsOptional() @IsString() notes?: string;
+	@ApiProperty({ format: "uuid", example: "3f2504e0-4f89-11d3-9a0c-0305e82c3301" })
+	@IsUUID()
+	patientId: string;
+	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
+	@IsUUID()
+	doctorId: string;
+	@ApiProperty({ format: "date-time", example: "2026-06-15T09:30:00.000Z" })
+	@IsDateString()
+	scheduledAt: string;
+	@ApiPropertyOptional({ example: "Follow-up consultation" })
+	@IsOptional()
+	@IsString()
+	notes?: string;
 }
 
 class UpdateAppointmentDto {
+	@ApiPropertyOptional({ enum: AppointmentStatusEnum })
 	@IsOptional()
 	@IsEnum(AppointmentStatusEnum)
 	status?: AppointmentStatus;
-	@IsOptional() @IsDateString() scheduledAt?: string;
-	@IsOptional() @IsString() notes?: string;
+	@ApiPropertyOptional({ format: "date-time", example: "2026-06-15T10:00:00.000Z" })
+	@IsOptional()
+	@IsDateString()
+	scheduledAt?: string;
+	@ApiPropertyOptional({ example: "Patient requested a later slot" })
+	@IsOptional()
+	@IsString()
+	notes?: string;
+}
+
+class AppointmentUserResponseDto {
+	@ApiProperty({ format: "uuid", example: "3f2504e0-4f89-11d3-9a0c-0305e82c3301" })
+	id!: string;
+
+	@ApiProperty({ example: "90bb0a13-a7be-4f8b-b071-e07d1f7b8bc2" })
+	keycloakId!: string;
+
+	@ApiProperty({ format: "email", example: "patient@example.com" })
+	email!: string;
+
+	@ApiProperty({ example: "Taylor" })
+	firstName!: string;
+
+	@ApiProperty({ example: "Brooks" })
+	lastName!: string;
+
+	@ApiProperty({ enum: ["patient", "doctor", "assistant", "admin"], example: "patient" })
+	role!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
+	createdAt!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+
+	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	deletedAt?: string | null;
+}
+
+class AppointmentPatientResponseDto {
+	@ApiProperty({ format: "uuid", example: "c56a4180-65aa-42ec-a945-5fd21dec0538" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "3f2504e0-4f89-11d3-9a0c-0305e82c3301" })
+	userId!: string;
+
+	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	dateOfBirth?: string | null;
+
+	@ApiPropertyOptional({ nullable: true, example: "+31 6 1234 5678" })
+	phone?: string | null;
+
+	@ApiPropertyOptional({ nullable: true, example: "INS-2026-001" })
+	insuranceNumber?: string | null;
+
+	@ApiPropertyOptional({ nullable: true, example: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ..." })
+	photo?: string | null;
+
+	@ApiProperty({ example: true })
+	emailNotificationsEnabled!: boolean;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+
+	@ApiProperty({ type: () => AppointmentUserResponseDto })
+	user!: AppointmentUserResponseDto;
+}
+
+class AppointmentDoctorResponseDto {
+	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "550e8400-e29b-41d4-a716-446655440000" })
+	userId!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Cardiology" })
+	specialization?: string | null;
+
+	@ApiPropertyOptional({ nullable: true, example: "MED-12345" })
+	licenseNumber?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+
+	@ApiProperty({ type: () => AppointmentUserResponseDto })
+	user!: AppointmentUserResponseDto;
+}
+
+class AppointmentAssistantResponseDto {
+	@ApiProperty({ format: "uuid", example: "de305d54-75b4-431b-adb2-eb6b9e546014" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "f47ac10b-58cc-4372-a567-0e02b2c3d479" })
+	userId!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Front Desk" })
+	department?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+
+	@ApiProperty({ type: () => AppointmentUserResponseDto })
+	user!: AppointmentUserResponseDto;
+}
+
+class AppointmentRecordResponseDto {
+	@ApiProperty({ format: "uuid", example: "7c9e6679-7425-40de-944b-e07fc1f90ae7" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "c56a4180-65aa-42ec-a945-5fd21dec0538" })
+	patientId!: string;
+
+	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
+	doctorId!: string;
+
+	@ApiPropertyOptional({ format: "uuid", nullable: true, example: "de305d54-75b4-431b-adb2-eb6b9e546014" })
+	assistantId?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-06-15T09:30:00.000Z" })
+	scheduledAt!: string;
+
+	@ApiProperty({ enum: AppointmentStatusEnum, example: AppointmentStatusEnum.SCHEDULED })
+	status!: AppointmentStatus;
+
+	@ApiPropertyOptional({ nullable: true, example: "Follow-up consultation" })
+	notes?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
+	createdAt!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+}
+
+class AppointmentResponseDto extends AppointmentRecordResponseDto {
+	@ApiProperty({ type: () => AppointmentPatientResponseDto })
+	patient!: AppointmentPatientResponseDto;
+
+	@ApiProperty({ type: () => AppointmentDoctorResponseDto })
+	doctor!: AppointmentDoctorResponseDto;
+
+	@ApiPropertyOptional({ type: () => AppointmentAssistantResponseDto, nullable: true })
+	assistant?: AppointmentAssistantResponseDto | null;
+}
+
+class AppointmentStatusCountsResponseDto {
+	@ApiProperty({ example: 12 })
+	SCHEDULED!: number;
+
+	@ApiProperty({ example: 8 })
+	CONFIRMED!: number;
+
+	@ApiProperty({ example: 31 })
+	COMPLETED!: number;
+
+	@ApiProperty({ example: 4 })
+	CANCELLED!: number;
+}
+
+class AppointmentStatsDataResponseDto {
+	@ApiProperty({ example: 5 })
+	todayCount!: number;
+
+	@ApiProperty({ example: 18 })
+	upcomingCount!: number;
+
+	@ApiProperty({ example: 31 })
+	completedCount!: number;
+
+	@ApiProperty({ example: 4 })
+	cancelledCount!: number;
+
+	@ApiProperty({ example: 55 })
+	totalCount!: number;
+
+	@ApiProperty({ type: () => AppointmentStatusCountsResponseDto })
+	byStatus!: AppointmentStatusCountsResponseDto;
+}
+
+class AppointmentStatusHistoryItemResponseDto {
+	@ApiProperty({ format: "uuid", example: "6ba7b810-9dad-11d1-80b4-00c04fd430c8" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "7c9e6679-7425-40de-944b-e07fc1f90ae7" })
+	appointmentId!: string;
+
+	@ApiPropertyOptional({ enum: AppointmentStatusEnum, nullable: true })
+	previousStatus?: AppointmentStatus | null;
+
+	@ApiProperty({ enum: AppointmentStatusEnum, example: AppointmentStatusEnum.CONFIRMED })
+	newStatus!: AppointmentStatus;
+
+	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	previousScheduledAt?: string | null;
+
+	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	newScheduledAt?: string | null;
+
+	@ApiProperty({ example: "90bb0a13-a7be-4f8b-b071-e07d1f7b8bc2" })
+	changedByKeycloakId!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:45:00.000Z" })
+	changedAt!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Jamie Lee" })
+	changedByName?: string | null;
+
+	@ApiPropertyOptional({ enum: ["patient", "doctor", "assistant", "admin"], nullable: true, example: "assistant" })
+	changedByRole?: string | null;
+}
+
+class AppointmentListResponseDto {
+	@ApiProperty({ type: () => AppointmentResponseDto, isArray: true })
+	data!: AppointmentResponseDto[];
+
+	@ApiProperty({ example: 42 })
+	total!: number;
+}
+
+class AppointmentStatsResponseDto {
+	@ApiProperty({ type: () => AppointmentStatsDataResponseDto })
+	data!: AppointmentStatsDataResponseDto;
+}
+
+class SingleAppointmentResponseDto {
+	@ApiProperty({ type: () => AppointmentResponseDto })
+	data!: AppointmentResponseDto;
+}
+
+class AppointmentHistoryResponseDto {
+	@ApiProperty({ type: () => AppointmentStatusHistoryItemResponseDto, isArray: true })
+	data!: AppointmentStatusHistoryItemResponseDto[];
+}
+
+class AppointmentCreatedResponseDto {
+	@ApiProperty({ type: () => AppointmentResponseDto })
+	data!: AppointmentResponseDto;
+
+	@ApiProperty({ example: "Appointment created" })
+	message!: string;
+}
+
+class AppointmentCancelledResponseDto {
+	@ApiProperty({ type: () => AppointmentRecordResponseDto })
+	data!: AppointmentRecordResponseDto;
+
+	@ApiProperty({ example: "Appointment cancelled" })
+	message!: string;
 }
 
 @ApiTags("appointments")
@@ -80,6 +345,7 @@ export class AppointmentsController {
 
 	@Get()
 	@ApiOperation({ summary: "Get all appointments (filterable)" })
+	@ApiOkResponse({ type: AppointmentListResponseDto })
 	@ApiQuery({ name: "status", required: false, enum: AppointmentStatusEnum })
 	@ApiQuery({ name: "doctorId", required: false, type: String })
 	@ApiQuery({ name: "from", required: false, type: String })
@@ -183,6 +449,7 @@ export class AppointmentsController {
 
 	@Get("stats")
 	@ApiOperation({ summary: "Get aggregate appointment stats across all appointments" })
+	@ApiOkResponse({ type: AppointmentStatsResponseDto })
 	async getStats(): Promise<{ data: AppointmentStats }> {
 		const now = new Date();
 		const todayStart = new Date(now);
@@ -220,6 +487,7 @@ export class AppointmentsController {
 
 	@Get(":id")
 	@ApiOperation({ summary: "Get appointment detail" })
+	@ApiOkResponse({ type: SingleAppointmentResponseDto })
 	async findOne(@Param("id", ParseUUIDPipe) id: string): Promise<{ data: ApptWithAll }> {
 		const appointment = await this.prisma.appointment.findUnique({
 			where: { id },
@@ -235,6 +503,7 @@ export class AppointmentsController {
 
 	@Get(":id/history")
 	@ApiOperation({ summary: "Get status change history for an appointment" })
+	@ApiOkResponse({ type: AppointmentHistoryResponseDto })
 	async getHistory(@Param("id", ParseUUIDPipe) id: string): Promise<{ data: EnrichedStatusChange[] }> {
 		const appointment = await this.prisma.appointment.findUnique({ where: { id } });
 		if (!appointment) throw new NotFoundException("Appointment not found");
@@ -265,6 +534,7 @@ export class AppointmentsController {
 
 	@Post()
 	@ApiOperation({ summary: "Create a new appointment" })
+	@ApiCreatedResponse({ type: AppointmentCreatedResponseDto })
 	async create(
 		@Body() dto: CreateAppointmentDto,
 		@CurrentUser() user: KeycloakTokenPayload
@@ -326,6 +596,7 @@ export class AppointmentsController {
 
 	@Put(":id")
 	@ApiOperation({ summary: "Update an appointment (reschedule or change status)" })
+	@ApiOkResponse({ type: SingleAppointmentResponseDto })
 	async update(
 		@Param("id", ParseUUIDPipe) id: string,
 		@Body() dto: UpdateAppointmentDto,
@@ -506,6 +777,7 @@ export class AppointmentsController {
 
 	@Delete(":id")
 	@ApiOperation({ summary: "Cancel an appointment" })
+	@ApiOkResponse({ type: AppointmentCancelledResponseDto })
 	async cancel(
 		@Param("id", ParseUUIDPipe) id: string,
 		@CurrentUser() user: KeycloakTokenPayload

--- a/apps/api-assistant/src/events/events.controller.ts
+++ b/apps/api-assistant/src/events/events.controller.ts
@@ -1,6 +1,6 @@
 import { EventsService, AppointmentEvent } from "@clinic/api-common";
 import { Controller, Sse, UseGuards } from "@nestjs/common";
-import { ApiTags, ApiBearerAuth } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiProduces, ApiTags } from "@nestjs/swagger";
 import { Observable, map } from "rxjs";
 
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
@@ -16,6 +16,16 @@ export class EventsController {
 	constructor(private readonly events: EventsService) {}
 
 	@Sse("appointments")
+	@ApiOperation({ summary: "Stream appointment events for assistants" })
+	@ApiProduces("text/event-stream")
+	@ApiOkResponse({
+		description: "Server-sent event stream carrying appointment event payloads.",
+		schema: {
+			type: "string",
+			example:
+				'data: {"type":"appointment.updated","appointmentId":"7c9e6679-7425-40de-944b-e07fc1f90ae7","patientId":"c56a4180-65aa-42ec-a945-5fd21dec0538","doctorId":"7d444840-9dc0-11d1-b245-5ffdce74fad2","status":"CONFIRMED","scheduledAt":"2026-06-15T09:30:00.000Z"}\n\n',
+		},
+	})
 	appointmentEvents(): Observable<MessageEvent> {
 		// Assistants see all appointment events
 		return this.events.appointment$.pipe(

--- a/apps/api-assistant/src/health/health.controller.ts
+++ b/apps/api-assistant/src/health/health.controller.ts
@@ -1,14 +1,18 @@
-import { Public } from "@clinic/api-common";
+import { HealthResponseDto, Public } from "@clinic/api-common";
 import { Controller, Get, ServiceUnavailableException } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 
 import { PrismaService } from "../prisma/prisma.service";
 
 @Public()
+@ApiTags("health")
 @Controller("health")
 export class HealthController {
 	constructor(private readonly prisma: PrismaService) {}
 
 	@Get()
+	@ApiOperation({ summary: "Liveness probe" })
+	@ApiOkResponse({ type: HealthResponseDto })
 	liveness(): { status: string; service: string; timestamp: string } {
 		return {
 			status: "ok",
@@ -18,6 +22,8 @@ export class HealthController {
 	}
 
 	@Get("ready")
+	@ApiOperation({ summary: "Readiness probe" })
+	@ApiOkResponse({ type: HealthResponseDto })
 	async readiness(): Promise<{ status: string; service: string; timestamp: string }> {
 		try {
 			await this.prisma.$queryRaw`SELECT 1`;

--- a/apps/api-assistant/src/patients/patients.controller.ts
+++ b/apps/api-assistant/src/patients/patients.controller.ts
@@ -1,3 +1,4 @@
+import { DoctorCoreResponseDto, PatientCoreResponseDto, UserCoreResponseDto } from "@clinic/api-common";
 import {
 	BadRequestException,
 	Controller,
@@ -12,7 +13,16 @@ import {
 	UseInterceptors,
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
-import { ApiBody, ApiConsumes, ApiOperation, ApiQuery, ApiTags, ApiBearerAuth } from "@nestjs/swagger";
+import {
+	ApiBearerAuth,
+	ApiBody,
+	ApiConsumes,
+	ApiOkResponse,
+	ApiOperation,
+	ApiProperty,
+	ApiQuery,
+	ApiTags,
+} from "@nestjs/swagger";
 import { Prisma } from "@prisma/client";
 import { IsOptional, IsString, MaxLength } from "class-validator";
 
@@ -35,6 +45,46 @@ class SearchPatientsQuery {
 	q?: string;
 }
 
+class AssistantPatientSearchResultResponseDto extends PatientCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class AssistantDoctorListItemResponseDto extends DoctorCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class AssistantPatientDetailResponseDto extends UserCoreResponseDto {
+	@ApiProperty({ type: () => PatientCoreResponseDto })
+	patient!: PatientCoreResponseDto;
+}
+
+class AssistantPatientsListResponseDto {
+	@ApiProperty({ type: () => AssistantPatientSearchResultResponseDto, isArray: true })
+	data!: AssistantPatientSearchResultResponseDto[];
+}
+
+class AssistantDoctorsListResponseDto {
+	@ApiProperty({ type: () => AssistantDoctorListItemResponseDto, isArray: true })
+	data!: AssistantDoctorListItemResponseDto[];
+}
+
+class AssistantPatientDetailWrapperDto {
+	@ApiProperty({ type: () => AssistantPatientDetailResponseDto })
+	data!: AssistantPatientDetailResponseDto;
+}
+
+class AssistantPatientPhotoDataDto {
+	@ApiProperty({ example: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ..." })
+	photo!: string;
+}
+
+class AssistantPatientPhotoResponseDto {
+	@ApiProperty({ type: () => AssistantPatientPhotoDataDto })
+	data!: AssistantPatientPhotoDataDto;
+}
+
 @ApiTags("patients")
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -45,6 +95,7 @@ export class PatientsController {
 
 	@Get()
 	@ApiOperation({ summary: "Search patients by name or email" })
+	@ApiOkResponse({ type: AssistantPatientsListResponseDto })
 	@ApiQuery({
 		name: "q",
 		required: false,
@@ -92,6 +143,7 @@ export class PatientsController {
 
 	@Get("doctors")
 	@ApiOperation({ summary: "List all active doctors (for appointment creation dropdown)" })
+	@ApiOkResponse({ type: AssistantDoctorsListResponseDto })
 	async listDoctors(): Promise<{ data: DoctorWithUser[] }> {
 		const doctors = await this.prisma.doctor.findMany({
 			where: { user: { deletedAt: null } },
@@ -103,6 +155,7 @@ export class PatientsController {
 
 	@Get(":id")
 	@ApiOperation({ summary: "Get patient detail by user ID" })
+	@ApiOkResponse({ type: AssistantPatientDetailWrapperDto })
 	async getById(@Param("id", ParseUUIDPipe) id: string): Promise<{ data: UserWithPatient }> {
 		const user = await this.prisma.user.findFirst({
 			where: { id, role: "patient", deletedAt: null },
@@ -115,6 +168,7 @@ export class PatientsController {
 	@Patch(":id/photo")
 	@ApiOperation({ summary: "Upload patient photo (1 MB max, portrait JPEG)" })
 	@ApiConsumes("multipart/form-data")
+	@ApiOkResponse({ type: AssistantPatientPhotoResponseDto })
 	@ApiBody({
 		schema: {
 			type: "object",

--- a/apps/api-assistant/src/prescriptions/prescriptions.controller.ts
+++ b/apps/api-assistant/src/prescriptions/prescriptions.controller.ts
@@ -1,5 +1,15 @@
+import {
+	AppointmentSummaryResponseDto,
+	DoctorCoreResponseDto,
+	PatientCoreResponseDto,
+	PrescriptionItemResponseDto,
+	PrescriptionRecordResponseDto,
+	UserNameEmailResponseDto,
+	UserNameResponseDto,
+} from "@clinic/api-common";
 import { Controller, Get, Param, ParseUUIDPipe, Query, UseGuards, NotFoundException } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiProperty, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { Prisma } from "@prisma/client";
 
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
 import { Roles } from "../auth/roles.decorator";
@@ -13,6 +23,47 @@ const PRESCRIPTION_INCLUDE = {
 	appointment: { select: { scheduledAt: true, status: true } },
 } as const;
 
+type PrescriptionWithRelations = Prisma.PrescriptionGetPayload<{
+	include: typeof PRESCRIPTION_INCLUDE;
+}>;
+
+class AssistantPrescriptionPatientResponseDto extends PatientCoreResponseDto {
+	@ApiProperty({ type: () => UserNameEmailResponseDto })
+	user!: UserNameEmailResponseDto;
+}
+
+class AssistantPrescriptionDoctorResponseDto extends DoctorCoreResponseDto {
+	@ApiProperty({ type: () => UserNameResponseDto })
+	user!: UserNameResponseDto;
+}
+
+class AssistantPrescriptionResponseDto extends PrescriptionRecordResponseDto {
+	@ApiProperty({ type: () => PrescriptionItemResponseDto, isArray: true })
+	items!: PrescriptionItemResponseDto[];
+
+	@ApiProperty({ type: () => AssistantPrescriptionPatientResponseDto })
+	patient!: AssistantPrescriptionPatientResponseDto;
+
+	@ApiProperty({ type: () => AssistantPrescriptionDoctorResponseDto })
+	doctor!: AssistantPrescriptionDoctorResponseDto;
+
+	@ApiProperty({ type: () => AppointmentSummaryResponseDto })
+	appointment!: AppointmentSummaryResponseDto;
+}
+
+class AssistantPrescriptionListResponseDto {
+	@ApiProperty({ type: () => AssistantPrescriptionResponseDto, isArray: true })
+	data!: AssistantPrescriptionResponseDto[];
+
+	@ApiProperty({ example: 42 })
+	total!: number;
+}
+
+class AssistantPrescriptionDetailResponseDto {
+	@ApiProperty({ type: () => AssistantPrescriptionResponseDto })
+	data!: AssistantPrescriptionResponseDto;
+}
+
 @ApiTags("prescriptions")
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -23,12 +74,13 @@ export class PrescriptionsController {
 
 	@Get()
 	@ApiOperation({ summary: "Get all recent prescriptions" })
+	@ApiOkResponse({ type: AssistantPrescriptionListResponseDto })
 	@ApiQuery({ name: "limit", required: false, type: Number })
 	@ApiQuery({ name: "offset", required: false, type: Number })
 	async findAll(
 		@Query("limit") limitRaw?: string,
 		@Query("offset") offsetRaw?: string
-	): Promise<{ data: unknown[]; total: number }> {
+	): Promise<{ data: PrescriptionWithRelations[]; total: number }> {
 		const take = Math.min(Number(limitRaw) || 50, 200);
 		const skip = Math.max(Number(offsetRaw) || 0, 0);
 
@@ -47,13 +99,14 @@ export class PrescriptionsController {
 
 	@Get("patient/:patientId")
 	@ApiOperation({ summary: "Get prescriptions for a specific patient" })
+	@ApiOkResponse({ type: AssistantPrescriptionListResponseDto })
 	@ApiQuery({ name: "limit", required: false, type: Number })
 	@ApiQuery({ name: "offset", required: false, type: Number })
 	async findByPatient(
 		@Param("patientId", ParseUUIDPipe) patientId: string,
 		@Query("limit") limitRaw?: string,
 		@Query("offset") offsetRaw?: string
-	): Promise<{ data: unknown[]; total: number }> {
+	): Promise<{ data: PrescriptionWithRelations[]; total: number }> {
 		const take = Math.min(Number(limitRaw) || 50, 200);
 		const skip = Math.max(Number(offsetRaw) || 0, 0);
 
@@ -77,13 +130,14 @@ export class PrescriptionsController {
 
 	@Get("doctor/:doctorId")
 	@ApiOperation({ summary: "Get prescriptions by a specific doctor" })
+	@ApiOkResponse({ type: AssistantPrescriptionListResponseDto })
 	@ApiQuery({ name: "limit", required: false, type: Number })
 	@ApiQuery({ name: "offset", required: false, type: Number })
 	async findByDoctor(
 		@Param("doctorId", ParseUUIDPipe) doctorId: string,
 		@Query("limit") limitRaw?: string,
 		@Query("offset") offsetRaw?: string
-	): Promise<{ data: unknown[]; total: number }> {
+	): Promise<{ data: PrescriptionWithRelations[]; total: number }> {
 		const take = Math.min(Number(limitRaw) || 50, 200);
 		const skip = Math.max(Number(offsetRaw) || 0, 0);
 
@@ -107,7 +161,8 @@ export class PrescriptionsController {
 
 	@Get(":id")
 	@ApiOperation({ summary: "Get a specific prescription" })
-	async findOne(@Param("id", ParseUUIDPipe) id: string): Promise<{ data: unknown }> {
+	@ApiOkResponse({ type: AssistantPrescriptionDetailResponseDto })
+	async findOne(@Param("id", ParseUUIDPipe) id: string): Promise<{ data: PrescriptionWithRelations }> {
 		const prescription = await this.prisma.prescription.findUnique({
 			where: { id },
 			include: PRESCRIPTION_INCLUDE,

--- a/apps/api-assistant/src/reviews/reviews.controller.ts
+++ b/apps/api-assistant/src/reviews/reviews.controller.ts
@@ -1,5 +1,98 @@
+import {
+	AppointmentDateResponseDto,
+	DoctorCoreResponseDto,
+	PatientCoreResponseDto,
+	ReviewRecordResponseDto,
+	ReviewStatsResponseDto,
+	UserNameResponseDto,
+} from "@clinic/api-common";
 import { Controller, Get, Param, ParseUUIDPipe, UseGuards, Query } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiProperty, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { Prisma } from "@prisma/client";
+
+const REVIEW_INCLUDE_ALL = {
+	patient: { include: { user: { select: { firstName: true, lastName: true } } } },
+	doctor: { include: { user: { select: { firstName: true, lastName: true } } } },
+	appointment: { select: { scheduledAt: true } },
+} as const;
+
+const REVIEW_INCLUDE_PATIENT = {
+	patient: { include: { user: { select: { firstName: true, lastName: true } } } },
+	appointment: { select: { scheduledAt: true } },
+} as const;
+
+const REVIEW_INCLUDE_DOCTOR = {
+	doctor: { include: { user: { select: { firstName: true, lastName: true } } } },
+	appointment: { select: { scheduledAt: true } },
+} as const;
+
+type AssistantReviewWithAll = Prisma.ReviewGetPayload<{ include: typeof REVIEW_INCLUDE_ALL }>;
+type AssistantDoctorReview = Prisma.ReviewGetPayload<{ include: typeof REVIEW_INCLUDE_PATIENT }>;
+type AssistantPatientReview = Prisma.ReviewGetPayload<{ include: typeof REVIEW_INCLUDE_DOCTOR }>;
+
+class AssistantReviewPatientResponseDto extends PatientCoreResponseDto {
+	@ApiProperty({ type: () => UserNameResponseDto })
+	user!: UserNameResponseDto;
+}
+
+class AssistantReviewDoctorResponseDto extends DoctorCoreResponseDto {
+	@ApiProperty({ type: () => UserNameResponseDto })
+	user!: UserNameResponseDto;
+}
+
+class AssistantReviewResponseDto extends ReviewRecordResponseDto {
+	@ApiProperty({ type: () => AssistantReviewPatientResponseDto })
+	patient!: AssistantReviewPatientResponseDto;
+
+	@ApiProperty({ type: () => AssistantReviewDoctorResponseDto })
+	doctor!: AssistantReviewDoctorResponseDto;
+
+	@ApiProperty({ type: () => AppointmentDateResponseDto })
+	appointment!: AppointmentDateResponseDto;
+}
+
+class AssistantDoctorReviewResponseDto extends ReviewRecordResponseDto {
+	@ApiProperty({ type: () => AssistantReviewPatientResponseDto })
+	patient!: AssistantReviewPatientResponseDto;
+
+	@ApiProperty({ type: () => AppointmentDateResponseDto })
+	appointment!: AppointmentDateResponseDto;
+}
+
+class AssistantPatientReviewResponseDto extends ReviewRecordResponseDto {
+	@ApiProperty({ type: () => AssistantReviewDoctorResponseDto })
+	doctor!: AssistantReviewDoctorResponseDto;
+
+	@ApiProperty({ type: () => AppointmentDateResponseDto })
+	appointment!: AppointmentDateResponseDto;
+}
+
+class AssistantReviewListResponseDto {
+	@ApiProperty({ type: () => AssistantReviewResponseDto, isArray: true })
+	data!: AssistantReviewResponseDto[];
+
+	@ApiProperty({ type: () => ReviewStatsResponseDto })
+	stats!: ReviewStatsResponseDto;
+
+	@ApiProperty({ example: 42 })
+	total!: number;
+}
+
+class AssistantDoctorReviewListResponseDto {
+	@ApiProperty({ type: () => AssistantDoctorReviewResponseDto, isArray: true })
+	data!: AssistantDoctorReviewResponseDto[];
+
+	@ApiProperty({ type: () => ReviewStatsResponseDto })
+	stats!: ReviewStatsResponseDto;
+
+	@ApiProperty({ example: 18 })
+	total!: number;
+}
+
+class AssistantPatientReviewListResponseDto {
+	@ApiProperty({ type: () => AssistantPatientReviewResponseDto, isArray: true })
+	data!: AssistantPatientReviewResponseDto[];
+}
 
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
 import { Roles } from "../auth/roles.decorator";
@@ -16,22 +109,23 @@ export class ReviewsController {
 
 	@Get()
 	@ApiOperation({ summary: "Get all recent reviews" })
+	@ApiOkResponse({ type: AssistantReviewListResponseDto })
 	@ApiQuery({ name: "limit", required: false, type: Number })
 	@ApiQuery({ name: "offset", required: false, type: Number })
 	async findAll(
 		@Query("limit") limitRaw?: string,
 		@Query("offset") offsetRaw?: string
-	): Promise<{ data: unknown[]; stats: { averageRating: number; totalReviews: number }; total: number }> {
+	): Promise<{
+		data: AssistantReviewWithAll[];
+		stats: { averageRating: number; totalReviews: number };
+		total: number;
+	}> {
 		const take = Math.min(Number(limitRaw) || 50, 200);
 		const skip = Math.max(Number(offsetRaw) || 0, 0);
 
 		const [reviews, total, stats] = await Promise.all([
 			this.prisma.review.findMany({
-				include: {
-					patient: { include: { user: { select: { firstName: true, lastName: true } } } },
-					doctor: { include: { user: { select: { firstName: true, lastName: true } } } },
-					appointment: { select: { scheduledAt: true } },
-				},
+				include: REVIEW_INCLUDE_ALL,
 				orderBy: { createdAt: "desc" },
 				take,
 				skip,
@@ -55,23 +149,21 @@ export class ReviewsController {
 
 	@Get("doctor/:doctorId")
 	@ApiOperation({ summary: "Get reviews for a specific doctor" })
+	@ApiOkResponse({ type: AssistantDoctorReviewListResponseDto })
 	@ApiQuery({ name: "limit", required: false, type: Number })
 	@ApiQuery({ name: "offset", required: false, type: Number })
 	async getDoctorReviews(
 		@Param("doctorId", ParseUUIDPipe) doctorId: string,
 		@Query("limit") limitRaw?: string,
 		@Query("offset") offsetRaw?: string
-	): Promise<{ data: unknown[]; stats: { averageRating: number; totalReviews: number }; total: number }> {
+	): Promise<{ data: AssistantDoctorReview[]; stats: { averageRating: number; totalReviews: number }; total: number }> {
 		const take = Math.min(Number(limitRaw) || 50, 200);
 		const skip = Math.max(Number(offsetRaw) || 0, 0);
 
 		const [reviews, total, stats] = await Promise.all([
 			this.prisma.review.findMany({
 				where: { doctorId },
-				include: {
-					patient: { include: { user: { select: { firstName: true, lastName: true } } } },
-					appointment: { select: { scheduledAt: true } },
-				},
+				include: REVIEW_INCLUDE_PATIENT,
 				orderBy: { createdAt: "desc" },
 				take,
 				skip,
@@ -96,13 +188,13 @@ export class ReviewsController {
 
 	@Get("patient/:patientId")
 	@ApiOperation({ summary: "Get reviews by a specific patient" })
-	async getPatientReviews(@Param("patientId", ParseUUIDPipe) patientId: string): Promise<{ data: unknown[] }> {
+	@ApiOkResponse({ type: AssistantPatientReviewListResponseDto })
+	async getPatientReviews(
+		@Param("patientId", ParseUUIDPipe) patientId: string
+	): Promise<{ data: AssistantPatientReview[] }> {
 		const reviews = await this.prisma.review.findMany({
 			where: { patientId },
-			include: {
-				doctor: { include: { user: { select: { firstName: true, lastName: true } } } },
-				appointment: { select: { scheduledAt: true } },
-			},
+			include: REVIEW_INCLUDE_DOCTOR,
 			orderBy: { createdAt: "desc" },
 			take: 50,
 		});

--- a/apps/api-doctor/src/appointments/appointments.controller.ts
+++ b/apps/api-doctor/src/appointments/appointments.controller.ts
@@ -1,4 +1,14 @@
-import { EventsService, MailService } from "@clinic/api-common";
+import {
+	AppointmentRecordResponseDto,
+	AppointmentStatsDataResponseDto,
+	AppointmentStatusHistoryItemResponseDto,
+	AssistantCoreResponseDto,
+	DoctorCoreResponseDto,
+	EventsService,
+	MailService,
+	PatientCoreResponseDto,
+	UserCoreResponseDto,
+} from "@clinic/api-common";
 import { ALLOWED_TRANSITIONS, AppointmentStatus } from "@clinic/shared-types";
 import {
 	Controller,
@@ -13,7 +23,15 @@ import {
 	ForbiddenException,
 	BadRequestException,
 } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from "@nestjs/swagger";
+import {
+	ApiBearerAuth,
+	ApiOkResponse,
+	ApiOperation,
+	ApiProperty,
+	ApiPropertyOptional,
+	ApiQuery,
+	ApiTags,
+} from "@nestjs/swagger";
 import { Prisma, AppointmentStatus as AppointmentStatusEnum, AppointmentStatusChange } from "@prisma/client";
 import { IsString, IsOptional, IsEnum, IsDateString } from "class-validator";
 
@@ -48,12 +66,76 @@ type EnrichedStatusChange = AppointmentStatusChange & {
 };
 
 class UpdateAppointmentDto {
+	@ApiPropertyOptional({ enum: AppointmentStatusEnum })
 	@IsOptional()
 	@IsEnum(AppointmentStatusEnum)
 	status?: AppointmentStatus;
 
-	@IsOptional() @IsString() notes?: string;
-	@IsOptional() @IsDateString() scheduledAt?: string;
+	@ApiPropertyOptional({ example: "Administrative note" })
+	@IsOptional()
+	@IsString()
+	notes?: string;
+	@ApiPropertyOptional({ format: "date-time", example: "2026-06-15T10:00:00.000Z" })
+	@IsOptional()
+	@IsDateString()
+	scheduledAt?: string;
+}
+
+class DoctorAppointmentPatientResponseDto extends PatientCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class DoctorAppointmentAssistantResponseDto extends AssistantCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class DoctorAppointmentDoctorResponseDto extends DoctorCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class DoctorAppointmentListItemResponseDto extends AppointmentRecordResponseDto {
+	@ApiProperty({ type: () => DoctorAppointmentPatientResponseDto })
+	patient!: DoctorAppointmentPatientResponseDto;
+
+	@ApiPropertyOptional({ type: () => DoctorAppointmentAssistantResponseDto, nullable: true })
+	assistant?: DoctorAppointmentAssistantResponseDto | null;
+}
+
+class DoctorAppointmentDetailResponseDto extends AppointmentRecordResponseDto {
+	@ApiProperty({ type: () => DoctorAppointmentPatientResponseDto })
+	patient!: DoctorAppointmentPatientResponseDto;
+
+	@ApiProperty({ type: () => DoctorAppointmentDoctorResponseDto })
+	doctor!: DoctorAppointmentDoctorResponseDto;
+
+	@ApiPropertyOptional({ type: () => DoctorAppointmentAssistantResponseDto, nullable: true })
+	assistant?: DoctorAppointmentAssistantResponseDto | null;
+}
+
+class DoctorAppointmentListResponseDto {
+	@ApiProperty({ type: () => DoctorAppointmentListItemResponseDto, isArray: true })
+	data!: DoctorAppointmentListItemResponseDto[];
+
+	@ApiProperty({ example: 42 })
+	total!: number;
+}
+
+class DoctorAppointmentStatsResponseDto {
+	@ApiProperty({ type: () => AppointmentStatsDataResponseDto })
+	data!: AppointmentStatsDataResponseDto;
+}
+
+class DoctorAppointmentDetailWrapperDto {
+	@ApiProperty({ type: () => DoctorAppointmentDetailResponseDto })
+	data!: DoctorAppointmentDetailResponseDto;
+}
+
+class DoctorAppointmentHistoryResponseDto {
+	@ApiProperty({ type: () => AppointmentStatusHistoryItemResponseDto, isArray: true })
+	data!: AppointmentStatusHistoryItemResponseDto[];
 }
 
 @ApiTags("appointments")
@@ -70,6 +152,7 @@ export class AppointmentsController {
 
 	@Get()
 	@ApiOperation({ summary: "Get doctor's appointments (filterable)" })
+	@ApiOkResponse({ type: DoctorAppointmentListResponseDto })
 	@ApiQuery({ name: "status", required: false, enum: AppointmentStatusEnum })
 	@ApiQuery({ name: "from", required: false, type: String })
 	@ApiQuery({ name: "to", required: false, type: String })
@@ -120,6 +203,7 @@ export class AppointmentsController {
 
 	@Get("stats")
 	@ApiOperation({ summary: "Get aggregate appointment stats for the current doctor" })
+	@ApiOkResponse({ type: DoctorAppointmentStatsResponseDto })
 	async getStats(@CurrentUser() user: KeycloakTokenPayload): Promise<{ data: AppointmentStats }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },
@@ -165,6 +249,7 @@ export class AppointmentsController {
 
 	@Get(":id")
 	@ApiOperation({ summary: "Get appointment detail" })
+	@ApiOkResponse({ type: DoctorAppointmentDetailWrapperDto })
 	async findOne(
 		@Param("id", ParseUUIDPipe) id: string,
 		@CurrentUser() user: KeycloakTokenPayload
@@ -190,6 +275,7 @@ export class AppointmentsController {
 
 	@Get(":id/history")
 	@ApiOperation({ summary: "Get status change history for an appointment" })
+	@ApiOkResponse({ type: DoctorAppointmentHistoryResponseDto })
 	async getHistory(
 		@Param("id", ParseUUIDPipe) id: string,
 		@CurrentUser() user: KeycloakTokenPayload
@@ -230,6 +316,7 @@ export class AppointmentsController {
 
 	@Put(":id")
 	@ApiOperation({ summary: "Update appointment status and/or notes" })
+	@ApiOkResponse({ type: DoctorAppointmentDetailWrapperDto })
 	async update(
 		@Param("id", ParseUUIDPipe) id: string,
 		@Body() dto: UpdateAppointmentDto,

--- a/apps/api-doctor/src/availability/availability.controller.ts
+++ b/apps/api-doctor/src/availability/availability.controller.ts
@@ -10,7 +10,16 @@ import {
 	NotFoundException,
 	BadRequestException,
 } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import {
+	ApiBearerAuth,
+	ApiCreatedResponse,
+	ApiOkResponse,
+	ApiOperation,
+	ApiProperty,
+	ApiPropertyOptional,
+	ApiTags,
+} from "@nestjs/swagger";
+import { DoctorUnavailability } from "@prisma/client";
 import { IsDateString, IsOptional, IsString } from "class-validator";
 
 import { CurrentUser } from "../auth/current-user.decorator";
@@ -21,15 +30,56 @@ import { RolesGuard } from "../auth/roles.guard";
 import { PrismaService } from "../prisma/prisma.service";
 
 class CreateUnavailabilityDto {
+	@ApiProperty({ format: "date-time", example: "2026-06-20T09:00:00.000Z" })
 	@IsDateString()
 	startDate!: string;
 
+	@ApiProperty({ format: "date-time", example: "2026-06-20T12:00:00.000Z" })
 	@IsDateString()
 	endDate!: string;
 
+	@ApiPropertyOptional({ example: "Medical conference" })
 	@IsOptional()
 	@IsString()
 	reason?: string;
+}
+
+class DoctorUnavailabilityResponseDto {
+	@ApiProperty({ format: "uuid", example: "6ba7b810-9dad-11d1-80b4-00c04fd430c8" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
+	doctorId!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-06-20T09:00:00.000Z" })
+	startDate!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-06-20T12:00:00.000Z" })
+	endDate!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Medical conference" })
+	reason?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
+	createdAt!: string;
+}
+
+class DoctorUnavailabilityListResponseDto {
+	@ApiProperty({ type: () => DoctorUnavailabilityResponseDto, isArray: true })
+	data!: DoctorUnavailabilityResponseDto[];
+}
+
+class DoctorUnavailabilityMutationResponseDto {
+	@ApiProperty({ type: () => DoctorUnavailabilityResponseDto })
+	data!: DoctorUnavailabilityResponseDto;
+
+	@ApiProperty({ example: "Unavailability block created" })
+	message!: string;
+}
+
+class DoctorAvailabilityMessageResponseDto {
+	@ApiProperty({ example: "Unavailability block deleted" })
+	message!: string;
 }
 
 @ApiTags("availability")
@@ -42,7 +92,8 @@ export class AvailabilityController {
 
 	@Get()
 	@ApiOperation({ summary: "Get all unavailability blocks for the current doctor" })
-	async findAll(@CurrentUser() user: KeycloakTokenPayload): Promise<{ data: unknown[] }> {
+	@ApiOkResponse({ type: DoctorUnavailabilityListResponseDto })
+	async findAll(@CurrentUser() user: KeycloakTokenPayload): Promise<{ data: DoctorUnavailability[] }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },
 			include: { doctor: true },
@@ -59,10 +110,11 @@ export class AvailabilityController {
 
 	@Post()
 	@ApiOperation({ summary: "Add a new unavailability block" })
+	@ApiCreatedResponse({ type: DoctorUnavailabilityMutationResponseDto })
 	async create(
 		@Body() dto: CreateUnavailabilityDto,
 		@CurrentUser() user: KeycloakTokenPayload
-	): Promise<{ data: unknown; message: string }> {
+	): Promise<{ data: DoctorUnavailability; message: string }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },
 			include: { doctor: true },
@@ -111,6 +163,7 @@ export class AvailabilityController {
 
 	@Delete(":id")
 	@ApiOperation({ summary: "Delete an unavailability block" })
+	@ApiOkResponse({ type: DoctorAvailabilityMessageResponseDto })
 	async remove(
 		@Param("id", ParseUUIDPipe) id: string,
 		@CurrentUser() user: KeycloakTokenPayload

--- a/apps/api-doctor/src/events/events.controller.ts
+++ b/apps/api-doctor/src/events/events.controller.ts
@@ -1,6 +1,6 @@
 import { EventsService, AppointmentEvent } from "@clinic/api-common";
 import { Controller, Sse, UseGuards, NotFoundException } from "@nestjs/common";
-import { ApiTags, ApiBearerAuth } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiProduces, ApiTags } from "@nestjs/swagger";
 import { Observable, filter, map } from "rxjs";
 
 import { CurrentUser } from "../auth/current-user.decorator";
@@ -22,6 +22,16 @@ export class EventsController {
 	) {}
 
 	@Sse("appointments")
+	@ApiOperation({ summary: "Stream appointment events for the current doctor" })
+	@ApiProduces("text/event-stream")
+	@ApiOkResponse({
+		description: "Server-sent event stream carrying appointment events for the authenticated doctor.",
+		schema: {
+			type: "string",
+			example:
+				'data: {"type":"appointment.updated","appointmentId":"7c9e6679-7425-40de-944b-e07fc1f90ae7","patientId":"c56a4180-65aa-42ec-a945-5fd21dec0538","doctorId":"7d444840-9dc0-11d1-b245-5ffdce74fad2","status":"CONFIRMED","scheduledAt":"2026-06-15T09:30:00.000Z"}\n\n',
+		},
+	})
 	async appointmentEvents(@CurrentUser() user: KeycloakTokenPayload): Promise<Observable<MessageEvent>> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },

--- a/apps/api-doctor/src/health/health.controller.ts
+++ b/apps/api-doctor/src/health/health.controller.ts
@@ -1,14 +1,18 @@
-import { Public } from "@clinic/api-common";
+import { HealthResponseDto, Public } from "@clinic/api-common";
 import { Controller, Get, ServiceUnavailableException } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 
 import { PrismaService } from "../prisma/prisma.service";
 
 @Public()
+@ApiTags("health")
 @Controller("health")
 export class HealthController {
 	constructor(private readonly prisma: PrismaService) {}
 
 	@Get()
+	@ApiOperation({ summary: "Liveness probe" })
+	@ApiOkResponse({ type: HealthResponseDto })
 	liveness(): { status: string; service: string; timestamp: string } {
 		return {
 			status: "ok",
@@ -18,6 +22,8 @@ export class HealthController {
 	}
 
 	@Get("ready")
+	@ApiOperation({ summary: "Readiness probe" })
+	@ApiOkResponse({ type: HealthResponseDto })
 	async readiness(): Promise<{ status: string; service: string; timestamp: string }> {
 		try {
 			await this.prisma.$queryRaw`SELECT 1`;

--- a/apps/api-doctor/src/patients/patients.controller.ts
+++ b/apps/api-doctor/src/patients/patients.controller.ts
@@ -1,3 +1,4 @@
+import { DoctorCoreResponseDto, PatientCoreResponseDto, UserCoreResponseDto } from "@clinic/api-common";
 import {
 	Controller,
 	Get,
@@ -7,7 +8,69 @@ import {
 	NotFoundException,
 	ForbiddenException,
 } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiProperty, ApiPropertyOptional, ApiTags } from "@nestjs/swagger";
+import { Prisma } from "@prisma/client";
+
+type PatientWithAppointments = Prisma.PatientGetPayload<{
+	include: {
+		user: true;
+		appointments: {
+			include: { doctor: { include: { user: true } } };
+		};
+	};
+}>;
+
+class DoctorPatientAppointmentDoctorResponseDto extends DoctorCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class DoctorPatientAppointmentResponseDto {
+	@ApiProperty({ format: "uuid", example: "7c9e6679-7425-40de-944b-e07fc1f90ae7" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "c56a4180-65aa-42ec-a945-5fd21dec0538" })
+	patientId!: string;
+
+	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
+	doctorId!: string;
+
+	@ApiPropertyOptional({ format: "uuid", nullable: true, example: "de305d54-75b4-431b-adb2-eb6b9e546014" })
+	assistantId?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-06-15T09:30:00.000Z" })
+	scheduledAt!: string;
+
+	@ApiProperty({ enum: ["SCHEDULED", "CONFIRMED", "CANCELLED", "COMPLETED"], example: "COMPLETED" })
+	status!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Follow-up consultation" })
+	notes?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
+	createdAt!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+
+	@ApiProperty({ type: () => DoctorPatientAppointmentDoctorResponseDto })
+	doctor!: DoctorPatientAppointmentDoctorResponseDto;
+}
+
+class DoctorPatientUserResponseDto extends UserCoreResponseDto {}
+
+class DoctorPatientDetailResponseDto extends PatientCoreResponseDto {
+	@ApiProperty({ type: () => DoctorPatientUserResponseDto })
+	user!: DoctorPatientUserResponseDto;
+
+	@ApiProperty({ type: () => DoctorPatientAppointmentResponseDto, isArray: true })
+	appointments!: DoctorPatientAppointmentResponseDto[];
+}
+
+class DoctorPatientDetailWrapperDto {
+	@ApiProperty({ type: () => DoctorPatientDetailResponseDto })
+	data!: DoctorPatientDetailResponseDto;
+}
 
 import { CurrentUser } from "../auth/current-user.decorator";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
@@ -26,10 +89,11 @@ export class PatientsController {
 
 	@Get(":id")
 	@ApiOperation({ summary: "Get patient details (for doctors who have an appointment with this patient)" })
+	@ApiOkResponse({ type: DoctorPatientDetailWrapperDto })
 	async findOne(
 		@Param("id", ParseUUIDPipe) id: string,
 		@CurrentUser() user: KeycloakTokenPayload
-	): Promise<{ data: unknown }> {
+	): Promise<{ data: PatientWithAppointments }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },
 			include: { doctor: true },

--- a/apps/api-doctor/src/prescriptions/prescriptions.controller.ts
+++ b/apps/api-doctor/src/prescriptions/prescriptions.controller.ts
@@ -1,4 +1,11 @@
 import {
+	AppointmentSummaryResponseDto,
+	PatientCoreResponseDto,
+	PrescriptionItemResponseDto,
+	PrescriptionRecordResponseDto,
+	UserNameEmailResponseDto,
+} from "@clinic/api-common";
+import {
 	Controller,
 	Get,
 	Post,
@@ -11,7 +18,17 @@ import {
 	NotFoundException,
 	BadRequestException,
 } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from "@nestjs/swagger";
+import {
+	ApiBearerAuth,
+	ApiCreatedResponse,
+	ApiOkResponse,
+	ApiOperation,
+	ApiProperty,
+	ApiPropertyOptional,
+	ApiQuery,
+	ApiTags,
+} from "@nestjs/swagger";
+import { Prisma } from "@prisma/client";
 import { Type } from "class-transformer";
 import { IsString, IsOptional, IsArray, ValidateNested, IsUUID } from "class-validator";
 
@@ -23,17 +40,34 @@ import { RolesGuard } from "../auth/roles.guard";
 import { PrismaService } from "../prisma/prisma.service";
 
 class PrescriptionItemDto {
-	@IsString() medicationName!: string;
-	@IsString() dosage!: string;
-	@IsString() frequency!: string;
-	@IsString() duration!: string;
-	@IsOptional() @IsString() instructions?: string;
+	@ApiProperty({ example: "Amoxicillin" })
+	@IsString()
+	medicationName!: string;
+	@ApiProperty({ example: "500 mg" })
+	@IsString()
+	dosage!: string;
+	@ApiProperty({ example: "Twice daily" })
+	@IsString()
+	frequency!: string;
+	@ApiProperty({ example: "7 days" })
+	@IsString()
+	duration!: string;
+	@ApiPropertyOptional({ example: "Take after meals" })
+	@IsOptional()
+	@IsString()
+	instructions?: string;
 }
 
 class CreatePrescriptionDto {
-	@IsUUID() appointmentId!: string;
-	@IsOptional() @IsString() notes?: string;
+	@ApiProperty({ format: "uuid", example: "0f8fad5b-d9cb-469f-a165-70867728950e" })
+	@IsUUID()
+	appointmentId!: string;
+	@ApiPropertyOptional({ example: "Monitor blood pressure during course" })
+	@IsOptional()
+	@IsString()
+	notes?: string;
 
+	@ApiProperty({ type: () => PrescriptionItemDto, isArray: true })
 	@IsArray()
 	@ValidateNested({ each: true })
 	@Type(() => PrescriptionItemDto)
@@ -41,8 +75,12 @@ class CreatePrescriptionDto {
 }
 
 class UpdatePrescriptionDto {
-	@IsOptional() @IsString() notes?: string;
+	@ApiPropertyOptional({ example: "Symptoms improving" })
+	@IsOptional()
+	@IsString()
+	notes?: string;
 
+	@ApiPropertyOptional({ type: () => PrescriptionItemDto, isArray: true })
 	@IsOptional()
 	@IsArray()
 	@ValidateNested({ each: true })
@@ -56,6 +94,47 @@ const PRESCRIPTION_INCLUDE = {
 	appointment: { select: { scheduledAt: true, status: true } },
 } as const;
 
+type PrescriptionWithRelations = Prisma.PrescriptionGetPayload<{
+	include: typeof PRESCRIPTION_INCLUDE;
+}>;
+
+class DoctorPrescriptionPatientResponseDto extends PatientCoreResponseDto {
+	@ApiProperty({ type: () => UserNameEmailResponseDto })
+	user!: UserNameEmailResponseDto;
+}
+
+class DoctorPrescriptionResponseDto extends PrescriptionRecordResponseDto {
+	@ApiProperty({ type: () => PrescriptionItemResponseDto, isArray: true })
+	items!: PrescriptionItemResponseDto[];
+
+	@ApiProperty({ type: () => DoctorPrescriptionPatientResponseDto })
+	patient!: DoctorPrescriptionPatientResponseDto;
+
+	@ApiProperty({ type: () => AppointmentSummaryResponseDto })
+	appointment!: AppointmentSummaryResponseDto;
+}
+
+class DoctorPrescriptionListResponseDto {
+	@ApiProperty({ type: () => DoctorPrescriptionResponseDto, isArray: true })
+	data!: DoctorPrescriptionResponseDto[];
+
+	@ApiProperty({ example: 42 })
+	total!: number;
+}
+
+class DoctorPrescriptionDetailResponseDto {
+	@ApiProperty({ type: () => DoctorPrescriptionResponseDto })
+	data!: DoctorPrescriptionResponseDto;
+}
+
+class DoctorPrescriptionMutationResponseDto {
+	@ApiProperty({ type: () => DoctorPrescriptionResponseDto })
+	data!: DoctorPrescriptionResponseDto;
+
+	@ApiProperty({ example: "Prescription created" })
+	message!: string;
+}
+
 @ApiTags("prescriptions")
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -66,13 +145,14 @@ export class PrescriptionsController {
 
 	@Get()
 	@ApiOperation({ summary: "Get prescriptions created by the current doctor" })
+	@ApiOkResponse({ type: DoctorPrescriptionListResponseDto })
 	@ApiQuery({ name: "limit", required: false, type: Number })
 	@ApiQuery({ name: "offset", required: false, type: Number })
 	async findAll(
 		@CurrentUser() user: KeycloakTokenPayload,
 		@Query("limit") limitRaw?: string,
 		@Query("offset") offsetRaw?: string
-	): Promise<{ data: unknown[]; total: number }> {
+	): Promise<{ data: PrescriptionWithRelations[]; total: number }> {
 		const take = Math.min(Number(limitRaw) || 50, 200);
 		const skip = Math.max(Number(offsetRaw) || 0, 0);
 
@@ -99,10 +179,11 @@ export class PrescriptionsController {
 
 	@Get(":id")
 	@ApiOperation({ summary: "Get a prescription by ID" })
+	@ApiOkResponse({ type: DoctorPrescriptionDetailResponseDto })
 	async findOne(
 		@Param("id", ParseUUIDPipe) id: string,
 		@CurrentUser() user: KeycloakTokenPayload
-	): Promise<{ data: unknown }> {
+	): Promise<{ data: PrescriptionWithRelations }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },
 			include: { doctor: true },
@@ -123,10 +204,11 @@ export class PrescriptionsController {
 
 	@Post()
 	@ApiOperation({ summary: "Create a prescription for a completed appointment" })
+	@ApiCreatedResponse({ type: DoctorPrescriptionMutationResponseDto })
 	async create(
 		@Body() dto: CreatePrescriptionDto,
 		@CurrentUser() user: KeycloakTokenPayload
-	): Promise<{ data: unknown; message: string }> {
+	): Promise<{ data: PrescriptionWithRelations; message: string }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },
 			include: { doctor: true },
@@ -180,11 +262,12 @@ export class PrescriptionsController {
 
 	@Put(":id")
 	@ApiOperation({ summary: "Update a prescription (replaces items if provided)" })
+	@ApiOkResponse({ type: DoctorPrescriptionMutationResponseDto })
 	async update(
 		@Param("id", ParseUUIDPipe) id: string,
 		@Body() dto: UpdatePrescriptionDto,
 		@CurrentUser() user: KeycloakTokenPayload
-	): Promise<{ data: unknown; message: string }> {
+	): Promise<{ data: PrescriptionWithRelations; message: string }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },
 			include: { doctor: true },

--- a/apps/api-doctor/src/profile/profile.controller.ts
+++ b/apps/api-doctor/src/profile/profile.controller.ts
@@ -1,5 +1,6 @@
+import { DoctorCoreResponseDto, UserCoreResponseDto } from "@clinic/api-common";
 import { Controller, Get, UseGuards, NotFoundException } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiProperty, ApiTags } from "@nestjs/swagger";
 import { Prisma } from "@prisma/client";
 
 import { CurrentUser } from "../auth/current-user.decorator";
@@ -11,6 +12,16 @@ import { PrismaService } from "../prisma/prisma.service";
 
 type UserWithDoctor = Prisma.UserGetPayload<{ include: { doctor: true } }>;
 
+class DoctorProfileResponseDto extends UserCoreResponseDto {
+	@ApiProperty({ type: () => DoctorCoreResponseDto })
+	doctor!: DoctorCoreResponseDto;
+}
+
+class DoctorProfileWrapperDto {
+	@ApiProperty({ type: () => DoctorProfileResponseDto })
+	data!: DoctorProfileResponseDto;
+}
+
 @ApiTags("profile")
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -21,6 +32,7 @@ export class ProfileController {
 
 	@Get("me")
 	@ApiOperation({ summary: "Get current doctor profile" })
+	@ApiOkResponse({ type: DoctorProfileWrapperDto })
 	async getMe(@CurrentUser() user: KeycloakTokenPayload): Promise<{ data: UserWithDoctor }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },

--- a/apps/api-doctor/src/reviews/reviews.controller.ts
+++ b/apps/api-doctor/src/reviews/reviews.controller.ts
@@ -1,5 +1,44 @@
+import {
+	AppointmentDateResponseDto,
+	PatientCoreResponseDto,
+	ReviewRecordResponseDto,
+	ReviewStatsResponseDto,
+	UserNameResponseDto,
+} from "@clinic/api-common";
 import { Controller, Get, UseGuards, NotFoundException, Query } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiProperty, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { Prisma } from "@prisma/client";
+
+const REVIEW_INCLUDE = {
+	patient: { include: { user: { select: { firstName: true, lastName: true } } } },
+	appointment: { select: { scheduledAt: true } },
+} as const;
+
+type DoctorReviewWithRelations = Prisma.ReviewGetPayload<{ include: typeof REVIEW_INCLUDE }>;
+
+class DoctorReviewPatientResponseDto extends PatientCoreResponseDto {
+	@ApiProperty({ type: () => UserNameResponseDto })
+	user!: UserNameResponseDto;
+}
+
+class DoctorReviewResponseDto extends ReviewRecordResponseDto {
+	@ApiProperty({ type: () => DoctorReviewPatientResponseDto })
+	patient!: DoctorReviewPatientResponseDto;
+
+	@ApiProperty({ type: () => AppointmentDateResponseDto })
+	appointment!: AppointmentDateResponseDto;
+}
+
+class DoctorReviewListResponseDto {
+	@ApiProperty({ type: () => DoctorReviewResponseDto, isArray: true })
+	data!: DoctorReviewResponseDto[];
+
+	@ApiProperty({ type: () => ReviewStatsResponseDto })
+	stats!: ReviewStatsResponseDto;
+
+	@ApiProperty({ example: 18 })
+	total!: number;
+}
 
 import { CurrentUser } from "../auth/current-user.decorator";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
@@ -18,13 +57,18 @@ export class ReviewsController {
 
 	@Get()
 	@ApiOperation({ summary: "Get reviews for the current doctor" })
+	@ApiOkResponse({ type: DoctorReviewListResponseDto })
 	@ApiQuery({ name: "limit", required: false, type: Number })
 	@ApiQuery({ name: "offset", required: false, type: Number })
 	async getMyReviews(
 		@CurrentUser() user: KeycloakTokenPayload,
 		@Query("limit") limitRaw?: string,
 		@Query("offset") offsetRaw?: string
-	): Promise<{ data: unknown[]; stats: { averageRating: number; totalReviews: number }; total: number }> {
+	): Promise<{
+		data: DoctorReviewWithRelations[];
+		stats: { averageRating: number; totalReviews: number };
+		total: number;
+	}> {
 		const take = Math.min(Number(limitRaw) || 50, 200);
 		const skip = Math.max(Number(offsetRaw) || 0, 0);
 
@@ -39,10 +83,7 @@ export class ReviewsController {
 		const [reviews, total, stats] = await Promise.all([
 			this.prisma.review.findMany({
 				where: { doctorId },
-				include: {
-					patient: { include: { user: { select: { firstName: true, lastName: true } } } },
-					appointment: { select: { scheduledAt: true } },
-				},
+				include: REVIEW_INCLUDE,
 				orderBy: { createdAt: "desc" },
 				take,
 				skip,

--- a/apps/api-patient/src/appointments/appointments.controller.ts
+++ b/apps/api-patient/src/appointments/appointments.controller.ts
@@ -1,4 +1,12 @@
-import { EventsService, MailService } from "@clinic/api-common";
+import {
+	AppointmentRecordResponseDto,
+	AssistantCoreResponseDto,
+	DoctorCoreResponseDto,
+	EventsService,
+	MailService,
+	PatientCoreResponseDto,
+	UserCoreResponseDto,
+} from "@clinic/api-common";
 import { AppointmentStatus } from "@clinic/shared-types";
 import {
 	Body,
@@ -14,7 +22,15 @@ import {
 	ForbiddenException,
 	BadRequestException,
 } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from "@nestjs/swagger";
+import {
+	ApiBearerAuth,
+	ApiOkResponse,
+	ApiOperation,
+	ApiProperty,
+	ApiPropertyOptional,
+	ApiQuery,
+	ApiTags,
+} from "@nestjs/swagger";
 import { Prisma } from "@prisma/client";
 import { IsDateString } from "class-validator";
 
@@ -40,8 +56,82 @@ type ApptWithAll = Prisma.AppointmentGetPayload<{
 }>;
 
 class RescheduleAppointmentDto {
+	@ApiProperty({ format: "date-time", example: "2026-06-15T10:30:00.000Z" })
 	@IsDateString()
 	scheduledAt!: string;
+}
+
+class PatientAppointmentDoctorResponseDto extends DoctorCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class PatientAppointmentAssistantResponseDto extends AssistantCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class PatientAppointmentPatientResponseDto extends PatientCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class PatientAppointmentListItemResponseDto extends AppointmentRecordResponseDto {
+	@ApiProperty({ type: () => PatientAppointmentDoctorResponseDto })
+	doctor!: PatientAppointmentDoctorResponseDto;
+
+	@ApiPropertyOptional({ type: () => PatientAppointmentAssistantResponseDto, nullable: true })
+	assistant?: PatientAppointmentAssistantResponseDto | null;
+}
+
+class PatientAppointmentHistoryItemResponseDto extends AppointmentRecordResponseDto {
+	@ApiProperty({ type: () => PatientAppointmentDoctorResponseDto })
+	doctor!: PatientAppointmentDoctorResponseDto;
+}
+
+class PatientAppointmentDetailResponseDto extends AppointmentRecordResponseDto {
+	@ApiProperty({ type: () => PatientAppointmentDoctorResponseDto })
+	doctor!: PatientAppointmentDoctorResponseDto;
+
+	@ApiPropertyOptional({ type: () => PatientAppointmentAssistantResponseDto, nullable: true })
+	assistant?: PatientAppointmentAssistantResponseDto | null;
+
+	@ApiProperty({ type: () => PatientAppointmentPatientResponseDto })
+	patient!: PatientAppointmentPatientResponseDto;
+}
+
+class PatientAppointmentMutationItemResponseDto extends AppointmentRecordResponseDto {
+	@ApiProperty({ type: () => PatientAppointmentDoctorResponseDto })
+	doctor!: PatientAppointmentDoctorResponseDto;
+}
+
+class PatientAppointmentListResponseDto {
+	@ApiProperty({ type: () => PatientAppointmentListItemResponseDto, isArray: true })
+	data!: PatientAppointmentListItemResponseDto[];
+
+	@ApiProperty({ example: 42 })
+	total!: number;
+}
+
+class PatientAppointmentHistoryResponseDto {
+	@ApiProperty({ type: () => PatientAppointmentHistoryItemResponseDto, isArray: true })
+	data!: PatientAppointmentHistoryItemResponseDto[];
+
+	@ApiProperty({ example: 18 })
+	total!: number;
+}
+
+class PatientAppointmentDetailWrapperDto {
+	@ApiProperty({ type: () => PatientAppointmentDetailResponseDto })
+	data!: PatientAppointmentDetailResponseDto;
+}
+
+class PatientAppointmentMutationResponseDto {
+	@ApiProperty({ type: () => PatientAppointmentMutationItemResponseDto })
+	data!: PatientAppointmentMutationItemResponseDto;
+
+	@ApiProperty({ example: "Appointment cancelled" })
+	message!: string;
 }
 
 /** Slot configuration (UTC working hours, 30-min increments) */
@@ -107,6 +197,7 @@ export class AppointmentsController {
 
 	@Get()
 	@ApiOperation({ summary: "Get current patient's appointments" })
+	@ApiOkResponse({ type: PatientAppointmentListResponseDto })
 	@ApiQuery({ name: "limit", required: false, type: Number })
 	@ApiQuery({ name: "offset", required: false, type: Number })
 	async findAll(
@@ -141,6 +232,7 @@ export class AppointmentsController {
 
 	@Get("history")
 	@ApiOperation({ summary: "Get current patient's completed appointment history" })
+	@ApiOkResponse({ type: PatientAppointmentHistoryResponseDto })
 	@ApiQuery({ name: "limit", required: false, type: Number })
 	@ApiQuery({ name: "offset", required: false, type: Number })
 	async getHistory(
@@ -174,6 +266,7 @@ export class AppointmentsController {
 
 	@Get(":id")
 	@ApiOperation({ summary: "Get a specific appointment (must belong to current patient)" })
+	@ApiOkResponse({ type: PatientAppointmentDetailWrapperDto })
 	async findOne(
 		@Param("id", ParseUUIDPipe) id: string,
 		@CurrentUser() user: KeycloakTokenPayload
@@ -201,6 +294,7 @@ export class AppointmentsController {
 
 	@Patch(":id/cancel")
 	@ApiOperation({ summary: "Cancel an appointment as the current patient" })
+	@ApiOkResponse({ type: PatientAppointmentMutationResponseDto })
 	async cancel(
 		@Param("id", ParseUUIDPipe) id: string,
 		@CurrentUser() user: KeycloakTokenPayload
@@ -286,6 +380,7 @@ export class AppointmentsController {
 
 	@Patch(":id/reschedule")
 	@ApiOperation({ summary: "Reschedule an appointment to a new free slot" })
+	@ApiOkResponse({ type: PatientAppointmentMutationResponseDto })
 	async reschedule(
 		@Param("id", ParseUUIDPipe) id: string,
 		@Body() dto: RescheduleAppointmentDto,

--- a/apps/api-patient/src/auth/auth.controller.ts
+++ b/apps/api-patient/src/auth/auth.controller.ts
@@ -1,6 +1,17 @@
-import { Public } from "@clinic/api-common";
+import { PatientCoreResponseDto, Public } from "@clinic/api-common";
 import { Controller, Post, Body, UseGuards, HttpCode, HttpStatus, BadRequestException, Logger } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiResponse } from "@nestjs/swagger";
+import {
+	ApiBearerAuth,
+	ApiCreatedResponse,
+	ApiNoContentResponse,
+	ApiOkResponse,
+	ApiOperation,
+	ApiProperty,
+	ApiPropertyOptional,
+	ApiResponse,
+	ApiTags,
+} from "@nestjs/swagger";
+import { Prisma } from "@prisma/client";
 import { IsEmail, IsString, MinLength, IsOptional, IsDateString, Matches } from "class-validator";
 
 import { PrismaService } from "../prisma/prisma.service";
@@ -13,27 +24,34 @@ import { Roles } from "./roles.decorator";
 import { RolesGuard } from "./roles.guard";
 
 class RegisterDto {
+	@ApiProperty({ format: "email", example: "patient@example.com" })
 	@IsEmail()
 	email!: string;
 
+	@ApiProperty({ example: "Taylor" })
 	@IsString()
 	firstName!: string;
 
+	@ApiProperty({ example: "Brooks" })
 	@IsString()
 	lastName!: string;
 
+	@ApiProperty({ minLength: 8, example: "StrongPass123", writeOnly: true })
 	@IsString()
 	@MinLength(8)
 	password!: string;
 
+	@ApiProperty({ minLength: 8, example: "StrongPass123", writeOnly: true })
 	@IsString()
 	@MinLength(8)
 	confirmPassword!: string;
 
+	@ApiPropertyOptional({ format: "date", example: "1990-01-15" })
 	@IsOptional()
 	@IsDateString()
 	dateOfBirth?: string;
 
+	@ApiPropertyOptional({ example: "+31 6 1234 5678" })
 	@IsOptional()
 	@IsString()
 	@Matches(/^[+\d\s\-().]{7,20}$/, { message: "Invalid phone number" })
@@ -41,8 +59,47 @@ class RegisterDto {
 }
 
 class ResendVerificationDto {
+	@ApiProperty({ format: "email", example: "patient@example.com" })
 	@IsEmail()
 	email!: string;
+}
+
+type SyncedUser = Omit<Prisma.UserGetPayload<{ include: { patient: true } }>, "keycloakId" | "deletedAt">;
+
+class AuthMessageResponseDto {
+	@ApiProperty({ example: "Account created. Please check your email to verify your address before signing in." })
+	message!: string;
+}
+
+class SyncedUserResponseDto {
+	@ApiProperty({ format: "uuid", example: "3f2504e0-4f89-11d3-9a0c-0305e82c3301" })
+	id!: string;
+
+	@ApiProperty({ format: "email", example: "patient@example.com" })
+	email!: string;
+
+	@ApiProperty({ example: "Taylor" })
+	firstName!: string;
+
+	@ApiProperty({ example: "Brooks" })
+	lastName!: string;
+
+	@ApiProperty({ enum: ["patient", "doctor", "assistant", "admin"], example: "patient" })
+	role!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
+	createdAt!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+
+	@ApiProperty({ type: () => PatientCoreResponseDto })
+	patient!: PatientCoreResponseDto;
+}
+
+class SyncedUserWrapperResponseDto {
+	@ApiProperty({ type: () => SyncedUserResponseDto })
+	data!: SyncedUserResponseDto;
 }
 
 // Minimum seconds between resend-verification attempts for the same email.
@@ -64,7 +121,7 @@ export class AuthController {
 	@Post("register")
 	@HttpCode(HttpStatus.CREATED)
 	@ApiOperation({ summary: "Register a new patient account" })
-	@ApiResponse({ status: 201, description: "Account created — verification email sent" })
+	@ApiCreatedResponse({ type: AuthMessageResponseDto, description: "Account created — verification email sent" })
 	@ApiResponse({ status: 409, description: "Email already registered" })
 	async register(@Body() dto: RegisterDto): Promise<{ message: string }> {
 		if (dto.password !== dto.confirmPassword) {
@@ -122,7 +179,7 @@ export class AuthController {
 	@Post("resend-verification")
 	@HttpCode(HttpStatus.NO_CONTENT)
 	@ApiOperation({ summary: "Resend the email verification link for a patient account" })
-	@ApiResponse({ status: 204, description: "Request accepted (response is intentionally opaque)" })
+	@ApiNoContentResponse({ description: "Request accepted (response is intentionally opaque)" })
 	async resendVerification(@Body() dto: ResendVerificationDto): Promise<void> {
 		const email = dto.email.trim().toLowerCase();
 
@@ -152,7 +209,8 @@ export class AuthController {
 	@ApiBearerAuth()
 	@HttpCode(HttpStatus.OK)
 	@ApiOperation({ summary: "Sync Keycloak patient user into local DB after first login" })
-	async syncUser(@CurrentUser() user: KeycloakTokenPayload): Promise<{ data: unknown }> {
+	@ApiOkResponse({ type: SyncedUserWrapperResponseDto })
+	async syncUser(@CurrentUser() user: KeycloakTokenPayload): Promise<{ data: SyncedUser }> {
 		// Only seed firstName/lastName from the Keycloak token on first login (create).
 		// On subsequent syncs, preserve any profile edits the patient has made in the portal;
 		// otherwise each visit to the home page would overwrite the DB with the token values.

--- a/apps/api-patient/src/doctors/doctors.controller.ts
+++ b/apps/api-patient/src/doctors/doctors.controller.ts
@@ -9,7 +9,15 @@ import {
 	Query,
 	UseGuards,
 } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from "@nestjs/swagger";
+import {
+	ApiBearerAuth,
+	ApiOkResponse,
+	ApiOperation,
+	ApiProperty,
+	ApiPropertyOptional,
+	ApiQuery,
+	ApiTags,
+} from "@nestjs/swagger";
 
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
 import { Roles } from "../auth/roles.decorator";
@@ -34,6 +42,57 @@ function buildDaySlots(): Array<{ hour: number; minute: number }> {
 }
 
 const DAY_SLOTS = buildDaySlots();
+
+type DoctorDirectoryItem = {
+	id: string;
+	userId: string;
+	specialization: string | null;
+	firstName: string;
+	lastName: string;
+	averageRating: number | null;
+	reviewCount: number;
+};
+
+class DoctorDirectoryItemResponseDto {
+	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "550e8400-e29b-41d4-a716-446655440000" })
+	userId!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Cardiology" })
+	specialization?: string | null;
+
+	@ApiProperty({ example: "Alex" })
+	firstName!: string;
+
+	@ApiProperty({ example: "Morgan" })
+	lastName!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: 4.7 })
+	averageRating?: number | null;
+
+	@ApiProperty({ example: 18 })
+	reviewCount!: number;
+}
+
+class DoctorDirectoryListResponseDto {
+	@ApiProperty({ type: () => DoctorDirectoryItemResponseDto, isArray: true })
+	data!: DoctorDirectoryItemResponseDto[];
+}
+
+class DoctorSlotAvailabilityResponseDto {
+	@ApiProperty({ example: "2026-06-20" })
+	date!: string;
+
+	@ApiProperty({ isArray: true, type: String, example: ["2026-06-20T09:00:00.000Z", "2026-06-20T09:30:00.000Z"] })
+	slots!: string[];
+}
+
+class DoctorSlotAvailabilityListResponseDto {
+	@ApiProperty({ type: () => DoctorSlotAvailabilityResponseDto, isArray: true })
+	data!: DoctorSlotAvailabilityResponseDto[];
+}
 
 /** Returns true for Mon–Fri (UTC day-of-week) */
 function isWeekday(date: Date): boolean {
@@ -69,7 +128,8 @@ export class DoctorsController {
 
 	@Get()
 	@ApiOperation({ summary: "List all active doctors (for patient reference)" })
-	async findAll(): Promise<{ data: unknown }> {
+	@ApiOkResponse({ type: DoctorDirectoryListResponseDto })
+	async findAll(): Promise<{ data: DoctorDirectoryItem[] }> {
 		const doctors = await this.prisma.doctor.findMany({
 			where: { user: { deletedAt: null } },
 			include: {
@@ -98,6 +158,7 @@ export class DoctorsController {
 
 	@Get(":doctorId/slots")
 	@ApiOperation({ summary: "Get available appointment slots for a doctor (future weekdays only)" })
+	@ApiOkResponse({ type: DoctorSlotAvailabilityListResponseDto })
 	@ApiQuery({
 		name: "from",
 		required: true,

--- a/apps/api-patient/src/events/events.controller.ts
+++ b/apps/api-patient/src/events/events.controller.ts
@@ -1,6 +1,6 @@
 import { EventsService, AppointmentEvent } from "@clinic/api-common";
 import { Controller, Sse, UseGuards, NotFoundException } from "@nestjs/common";
-import { ApiTags, ApiBearerAuth } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiProduces, ApiTags } from "@nestjs/swagger";
 import { Observable, filter, map } from "rxjs";
 
 import { CurrentUser } from "../auth/current-user.decorator";
@@ -22,6 +22,16 @@ export class EventsController {
 	) {}
 
 	@Sse("appointments")
+	@ApiOperation({ summary: "Stream appointment events for the current patient" })
+	@ApiProduces("text/event-stream")
+	@ApiOkResponse({
+		description: "Server-sent event stream carrying appointment events for the authenticated patient.",
+		schema: {
+			type: "string",
+			example:
+				'data: {"type":"appointment.updated","appointmentId":"7c9e6679-7425-40de-944b-e07fc1f90ae7","patientId":"c56a4180-65aa-42ec-a945-5fd21dec0538","doctorId":"7d444840-9dc0-11d1-b245-5ffdce74fad2","status":"CONFIRMED","scheduledAt":"2026-06-15T09:30:00.000Z"}\n\n',
+		},
+	})
 	async appointmentEvents(@CurrentUser() user: KeycloakTokenPayload): Promise<Observable<MessageEvent>> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },

--- a/apps/api-patient/src/health/health.controller.ts
+++ b/apps/api-patient/src/health/health.controller.ts
@@ -1,14 +1,18 @@
-import { Public } from "@clinic/api-common";
+import { HealthResponseDto, Public } from "@clinic/api-common";
 import { Controller, Get, ServiceUnavailableException } from "@nestjs/common";
+import { ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 
 import { PrismaService } from "../prisma/prisma.service";
 
 @Public()
+@ApiTags("health")
 @Controller("health")
 export class HealthController {
 	constructor(private readonly prisma: PrismaService) {}
 
 	@Get()
+	@ApiOperation({ summary: "Liveness probe" })
+	@ApiOkResponse({ type: HealthResponseDto })
 	liveness(): { status: string; service: string; timestamp: string } {
 		return {
 			status: "ok",
@@ -18,6 +22,8 @@ export class HealthController {
 	}
 
 	@Get("ready")
+	@ApiOperation({ summary: "Readiness probe" })
+	@ApiOkResponse({ type: HealthResponseDto })
 	async readiness(): Promise<{ status: string; service: string; timestamp: string }> {
 		try {
 			await this.prisma.$queryRaw`SELECT 1`;

--- a/apps/api-patient/src/prescriptions/prescriptions.controller.ts
+++ b/apps/api-patient/src/prescriptions/prescriptions.controller.ts
@@ -1,4 +1,11 @@
 import {
+	AppointmentSummaryResponseDto,
+	DoctorCoreResponseDto,
+	PrescriptionItemResponseDto,
+	PrescriptionRecordResponseDto,
+	UserNameResponseDto,
+} from "@clinic/api-common";
+import {
 	Controller,
 	Get,
 	Param,
@@ -8,7 +15,8 @@ import {
 	NotFoundException,
 	ForbiddenException,
 } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiProperty, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { Prisma } from "@prisma/client";
 
 import { CurrentUser } from "../auth/current-user.decorator";
 import { JwtAuthGuard } from "../auth/jwt-auth.guard";
@@ -23,6 +31,39 @@ const PRESCRIPTION_INCLUDE = {
 	appointment: { select: { scheduledAt: true, status: true } },
 } as const;
 
+type PrescriptionWithRelations = Prisma.PrescriptionGetPayload<{
+	include: typeof PRESCRIPTION_INCLUDE;
+}>;
+
+class PatientPrescriptionDoctorResponseDto extends DoctorCoreResponseDto {
+	@ApiProperty({ type: () => UserNameResponseDto })
+	user!: UserNameResponseDto;
+}
+
+class PatientPrescriptionResponseDto extends PrescriptionRecordResponseDto {
+	@ApiProperty({ type: () => PrescriptionItemResponseDto, isArray: true })
+	items!: PrescriptionItemResponseDto[];
+
+	@ApiProperty({ type: () => PatientPrescriptionDoctorResponseDto })
+	doctor!: PatientPrescriptionDoctorResponseDto;
+
+	@ApiProperty({ type: () => AppointmentSummaryResponseDto })
+	appointment!: AppointmentSummaryResponseDto;
+}
+
+class PatientPrescriptionListResponseDto {
+	@ApiProperty({ type: () => PatientPrescriptionResponseDto, isArray: true })
+	data!: PatientPrescriptionResponseDto[];
+
+	@ApiProperty({ example: 42 })
+	total!: number;
+}
+
+class PatientPrescriptionDetailResponseDto {
+	@ApiProperty({ type: () => PatientPrescriptionResponseDto })
+	data!: PatientPrescriptionResponseDto;
+}
+
 @ApiTags("prescriptions")
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -33,13 +74,14 @@ export class PrescriptionsController {
 
 	@Get()
 	@ApiOperation({ summary: "Get current patient's prescriptions" })
+	@ApiOkResponse({ type: PatientPrescriptionListResponseDto })
 	@ApiQuery({ name: "limit", required: false, type: Number })
 	@ApiQuery({ name: "offset", required: false, type: Number })
 	async findAll(
 		@CurrentUser() user: KeycloakTokenPayload,
 		@Query("limit") limitRaw?: string,
 		@Query("offset") offsetRaw?: string
-	): Promise<{ data: unknown[]; total: number }> {
+	): Promise<{ data: PrescriptionWithRelations[]; total: number }> {
 		const take = Math.min(Number(limitRaw) || 50, 200);
 		const skip = Math.max(Number(offsetRaw) || 0, 0);
 
@@ -66,10 +108,11 @@ export class PrescriptionsController {
 
 	@Get(":id")
 	@ApiOperation({ summary: "Get a specific prescription" })
+	@ApiOkResponse({ type: PatientPrescriptionDetailResponseDto })
 	async findOne(
 		@Param("id", ParseUUIDPipe) id: string,
 		@CurrentUser() user: KeycloakTokenPayload
-	): Promise<{ data: unknown }> {
+	): Promise<{ data: PrescriptionWithRelations }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },
 			include: { patient: true },

--- a/apps/api-patient/src/profile/profile.controller.ts
+++ b/apps/api-patient/src/profile/profile.controller.ts
@@ -1,3 +1,4 @@
+import { PatientCoreResponseDto, UserCoreResponseDto } from "@clinic/api-common";
 import { FEATURE_TOGGLE_KEYS } from "@clinic/shared-types";
 import {
 	BadRequestException,
@@ -12,7 +13,16 @@ import {
 	UseInterceptors,
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
-import { ApiBody, ApiConsumes, ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import {
+	ApiBearerAuth,
+	ApiBody,
+	ApiConsumes,
+	ApiOkResponse,
+	ApiOperation,
+	ApiProperty,
+	ApiPropertyOptional,
+	ApiTags,
+} from "@nestjs/swagger";
 import { Prisma } from "@prisma/client";
 import { IsString, IsOptional, IsDateString } from "class-validator";
 
@@ -28,14 +38,61 @@ const MAX_FILE_BYTES = 1 * 1024 * 1024; // 1 MB
 const PHONE_REGEX = /^[+\d\s\-().]{7,20}$/;
 
 class UpdateProfileDto {
-	@IsOptional() @IsString() firstName?: string;
-	@IsOptional() @IsString() lastName?: string;
-	@IsOptional() @IsDateString() dateOfBirth?: string;
-	@IsOptional() @IsString() phone?: string;
-	@IsOptional() @IsString() insuranceNumber?: string;
+	@ApiPropertyOptional({ example: "Taylor" })
+	@IsOptional()
+	@IsString()
+	firstName?: string;
+	@ApiPropertyOptional({ example: "Brooks" })
+	@IsOptional()
+	@IsString()
+	lastName?: string;
+	@ApiPropertyOptional({ format: "date", example: "1990-01-15" })
+	@IsOptional()
+	@IsDateString()
+	dateOfBirth?: string;
+	@ApiPropertyOptional({ example: "+31 6 1234 5678" })
+	@IsOptional()
+	@IsString()
+	phone?: string;
+	@ApiPropertyOptional({ example: "INS-2026-001" })
+	@IsOptional()
+	@IsString()
+	insuranceNumber?: string;
 }
 
 type UserWithPatient = Prisma.UserGetPayload<{ include: { patient: true } }>;
+
+class ProfileFeatureToggleMapResponseDto {
+	@ApiProperty({
+		type: Object,
+		additionalProperties: { type: "boolean" },
+		example: {
+			[FEATURE_TOGGLE_KEYS.PROFILE_VALIDATION_FRONTEND]: false,
+			[FEATURE_TOGGLE_KEYS.PROFILE_VALIDATION_BACKEND]: true,
+		},
+	})
+	data!: Record<string, boolean>;
+}
+
+class PatientProfileResponseDto extends UserCoreResponseDto {
+	@ApiProperty({ type: () => PatientCoreResponseDto })
+	patient!: PatientCoreResponseDto;
+}
+
+class PatientProfileWrapperDto {
+	@ApiProperty({ type: () => PatientProfileResponseDto })
+	data!: PatientProfileResponseDto;
+}
+
+class PatientProfilePhotoDataDto {
+	@ApiProperty({ example: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ..." })
+	photo!: string;
+}
+
+class PatientProfilePhotoResponseDto {
+	@ApiProperty({ type: () => PatientProfilePhotoDataDto })
+	data!: PatientProfilePhotoDataDto;
+}
 
 function isInvalidDateOfBirth(dateOfBirth: string): boolean {
 	const dob = new Date(dateOfBirth);
@@ -72,6 +129,7 @@ export class ProfileController {
 
 	@Get("feature-toggles")
 	@ApiOperation({ summary: "Get profile-related feature toggle states" })
+	@ApiOkResponse({ type: ProfileFeatureToggleMapResponseDto })
 	async getFeatureToggles(): Promise<{ data: Record<string, boolean> }> {
 		const keys = [FEATURE_TOGGLE_KEYS.PROFILE_VALIDATION_FRONTEND, FEATURE_TOGGLE_KEYS.PROFILE_VALIDATION_BACKEND];
 		const toggles = await this.prisma.featureToggle.findMany({ where: { key: { in: keys } } }).catch(() => []);
@@ -84,6 +142,7 @@ export class ProfileController {
 
 	@Get()
 	@ApiOperation({ summary: "Get current patient profile" })
+	@ApiOkResponse({ type: PatientProfileWrapperDto })
 	async getProfile(@CurrentUser() user: KeycloakTokenPayload): Promise<{ data: UserWithPatient }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },
@@ -95,6 +154,7 @@ export class ProfileController {
 
 	@Put()
 	@ApiOperation({ summary: "Update current patient profile" })
+	@ApiOkResponse({ type: PatientProfileWrapperDto })
 	async updateProfile(
 		@CurrentUser() user: KeycloakTokenPayload,
 		@Body() dto: UpdateProfileDto
@@ -140,6 +200,7 @@ export class ProfileController {
 	@Patch("photo")
 	@ApiOperation({ summary: "Upload profile photo (1 MB max, JPEG/PNG/WebP)" })
 	@ApiConsumes("multipart/form-data")
+	@ApiOkResponse({ type: PatientProfilePhotoResponseDto })
 	@ApiBody({
 		schema: {
 			type: "object",

--- a/apps/api-patient/src/reviews/reviews.controller.ts
+++ b/apps/api-patient/src/reviews/reviews.controller.ts
@@ -1,4 +1,13 @@
 import {
+	AppointmentDateResponseDto,
+	DoctorCoreResponseDto,
+	PatientCoreResponseDto,
+	ReviewRecordResponseDto,
+	ReviewStatsResponseDto,
+	UserCoreResponseDto,
+	UserNameResponseDto,
+} from "@clinic/api-common";
+import {
 	Controller,
 	Post,
 	Get,
@@ -10,7 +19,16 @@ import {
 	ForbiddenException,
 	BadRequestException,
 } from "@nestjs/common";
-import { ApiTags, ApiOperation, ApiBearerAuth } from "@nestjs/swagger";
+import {
+	ApiBearerAuth,
+	ApiCreatedResponse,
+	ApiOkResponse,
+	ApiOperation,
+	ApiProperty,
+	ApiPropertyOptional,
+	ApiTags,
+} from "@nestjs/swagger";
+import { Prisma, Review } from "@prisma/client";
 import { IsInt, IsOptional, IsString, Max, Min } from "class-validator";
 
 import { CurrentUser } from "../auth/current-user.decorator";
@@ -21,14 +39,74 @@ import { RolesGuard } from "../auth/roles.guard";
 import { PrismaService } from "../prisma/prisma.service";
 
 class CreateReviewDto {
+	@ApiProperty({ minimum: 1, maximum: 5, example: 5 })
 	@IsInt()
 	@Min(1)
 	@Max(5)
 	rating!: number;
 
+	@ApiPropertyOptional({ example: "Very clear explanation and punctual consultation." })
 	@IsOptional()
 	@IsString()
 	comment?: string;
+}
+
+const REVIEW_CREATE_INCLUDE = {
+	doctor: { include: { user: true } },
+} as const;
+
+const REVIEW_LIST_INCLUDE = {
+	patient: { include: { user: { select: { firstName: true, lastName: true } } } },
+	appointment: { select: { scheduledAt: true } },
+} as const;
+
+type CreatedReviewWithDoctor = Prisma.ReviewGetPayload<{ include: typeof REVIEW_CREATE_INCLUDE }>;
+type DoctorReviewWithRelations = Prisma.ReviewGetPayload<{ include: typeof REVIEW_LIST_INCLUDE }>;
+
+class PatientReviewDoctorResponseDto extends DoctorCoreResponseDto {
+	@ApiProperty({ type: () => UserCoreResponseDto })
+	user!: UserCoreResponseDto;
+}
+
+class PatientCreatedReviewResponseDto extends ReviewRecordResponseDto {
+	@ApiProperty({ type: () => PatientReviewDoctorResponseDto })
+	doctor!: PatientReviewDoctorResponseDto;
+}
+
+class PatientAppointmentReviewResponseDto extends ReviewRecordResponseDto {}
+
+class PatientDoctorReviewPatientResponseDto extends PatientCoreResponseDto {
+	@ApiProperty({ type: () => UserNameResponseDto })
+	user!: UserNameResponseDto;
+}
+
+class PatientDoctorReviewResponseDto extends ReviewRecordResponseDto {
+	@ApiProperty({ type: () => PatientDoctorReviewPatientResponseDto })
+	patient!: PatientDoctorReviewPatientResponseDto;
+
+	@ApiProperty({ type: () => AppointmentDateResponseDto })
+	appointment!: AppointmentDateResponseDto;
+}
+
+class PatientReviewMutationResponseDto {
+	@ApiProperty({ type: () => PatientCreatedReviewResponseDto })
+	data!: PatientCreatedReviewResponseDto;
+
+	@ApiProperty({ example: "Review submitted successfully" })
+	message!: string;
+}
+
+class PatientAppointmentReviewWrapperDto {
+	@ApiProperty({ type: () => PatientAppointmentReviewResponseDto, nullable: true })
+	data!: PatientAppointmentReviewResponseDto | null;
+}
+
+class PatientDoctorReviewListResponseDto {
+	@ApiProperty({ type: () => PatientDoctorReviewResponseDto, isArray: true })
+	data!: PatientDoctorReviewResponseDto[];
+
+	@ApiProperty({ type: () => ReviewStatsResponseDto })
+	stats!: ReviewStatsResponseDto;
 }
 
 @ApiTags("reviews")
@@ -41,11 +119,12 @@ export class ReviewsController {
 
 	@Post("appointments/:appointmentId/reviews")
 	@ApiOperation({ summary: "Create a review for a completed appointment" })
+	@ApiCreatedResponse({ type: PatientReviewMutationResponseDto })
 	async create(
 		@Param("appointmentId", ParseUUIDPipe) appointmentId: string,
 		@Body() dto: CreateReviewDto,
 		@CurrentUser() user: KeycloakTokenPayload
-	): Promise<{ data: unknown; message: string }> {
+	): Promise<{ data: CreatedReviewWithDoctor; message: string }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },
 			include: { patient: true },
@@ -77,9 +156,7 @@ export class ReviewsController {
 				rating: dto.rating,
 				comment: dto.comment,
 			},
-			include: {
-				doctor: { include: { user: true } },
-			},
+			include: REVIEW_CREATE_INCLUDE,
 		});
 
 		return { data: review, message: "Review submitted successfully" };
@@ -87,10 +164,11 @@ export class ReviewsController {
 
 	@Get("appointments/:appointmentId/reviews")
 	@ApiOperation({ summary: "Get review for a specific appointment" })
+	@ApiOkResponse({ type: PatientAppointmentReviewWrapperDto })
 	async getForAppointment(
 		@Param("appointmentId", ParseUUIDPipe) appointmentId: string,
 		@CurrentUser() user: KeycloakTokenPayload
-	): Promise<{ data: unknown }> {
+	): Promise<{ data: Review | null }> {
 		const dbUser = await this.prisma.user.findUnique({
 			where: { keycloakId: user.sub, deletedAt: null },
 			include: { patient: true },
@@ -112,15 +190,13 @@ export class ReviewsController {
 
 	@Get("doctors/:doctorId/reviews")
 	@ApiOperation({ summary: "Get reviews for a doctor" })
+	@ApiOkResponse({ type: PatientDoctorReviewListResponseDto })
 	async getDoctorReviews(
 		@Param("doctorId", ParseUUIDPipe) doctorId: string
-	): Promise<{ data: unknown[]; stats: { averageRating: number; totalReviews: number } }> {
+	): Promise<{ data: DoctorReviewWithRelations[]; stats: { averageRating: number; totalReviews: number } }> {
 		const reviews = await this.prisma.review.findMany({
 			where: { doctorId },
-			include: {
-				patient: { include: { user: { select: { firstName: true, lastName: true } } } },
-				appointment: { select: { scheduledAt: true } },
-			},
+			include: REVIEW_LIST_INCLUDE,
 			orderBy: { createdAt: "desc" },
 			take: 50,
 		});

--- a/packages/api-common/src/index.ts
+++ b/packages/api-common/src/index.ts
@@ -12,4 +12,5 @@ export * from "./prisma-exception.filter";
 export * from "./prisma.module";
 export * from "./prisma.service";
 export * from "./slowdown.middleware";
+export * from "./swagger-response.dto";
 export * from "./ui-toggles.module";

--- a/packages/api-common/src/swagger-response.dto.ts
+++ b/packages/api-common/src/swagger-response.dto.ts
@@ -1,0 +1,351 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+
+export class UserNameResponseDto {
+	@ApiProperty({ example: "Alex" })
+	firstName!: string;
+
+	@ApiProperty({ example: "Morgan" })
+	lastName!: string;
+}
+
+export class UserNameEmailResponseDto extends UserNameResponseDto {
+	@ApiProperty({ format: "email", example: "patient@example.com" })
+	email!: string;
+}
+
+export class UserCoreResponseDto {
+	@ApiProperty({ format: "uuid", example: "3f2504e0-4f89-11d3-9a0c-0305e82c3301" })
+	id!: string;
+
+	@ApiProperty({ example: "90bb0a13-a7be-4f8b-b071-e07d1f7b8bc2" })
+	keycloakId!: string;
+
+	@ApiProperty({ format: "email", example: "doctor@example.com" })
+	email!: string;
+
+	@ApiProperty({ example: "Alex" })
+	firstName!: string;
+
+	@ApiProperty({ example: "Morgan" })
+	lastName!: string;
+
+	@ApiProperty({ enum: ["patient", "doctor", "assistant", "admin"], example: "doctor" })
+	role!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
+	createdAt!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+
+	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	deletedAt?: string | null;
+}
+
+export class PatientCoreResponseDto {
+	@ApiProperty({ format: "uuid", example: "c56a4180-65aa-42ec-a945-5fd21dec0538" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "3f2504e0-4f89-11d3-9a0c-0305e82c3301" })
+	userId!: string;
+
+	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	dateOfBirth?: string | null;
+
+	@ApiPropertyOptional({ nullable: true, example: "+31 6 1234 5678" })
+	phone?: string | null;
+
+	@ApiPropertyOptional({ nullable: true, example: "INS-2026-001" })
+	insuranceNumber?: string | null;
+
+	@ApiPropertyOptional({ nullable: true, example: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ..." })
+	photo?: string | null;
+
+	@ApiProperty({ example: true })
+	emailNotificationsEnabled!: boolean;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+}
+
+export class DoctorCoreResponseDto {
+	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "550e8400-e29b-41d4-a716-446655440000" })
+	userId!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Cardiology" })
+	specialization?: string | null;
+
+	@ApiPropertyOptional({ nullable: true, example: "MED-12345" })
+	licenseNumber?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+}
+
+export class AssistantCoreResponseDto {
+	@ApiProperty({ format: "uuid", example: "de305d54-75b4-431b-adb2-eb6b9e546014" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "f47ac10b-58cc-4372-a567-0e02b2c3d479" })
+	userId!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Front Desk" })
+	department?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+}
+
+export class MessageResponseDto {
+	@ApiProperty({ example: "Operation completed successfully" })
+	message!: string;
+}
+
+export class HealthResponseDto {
+	@ApiProperty({ example: "ok" })
+	status!: string;
+
+	@ApiProperty({ example: "api-assistant" })
+	service!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	timestamp!: string;
+}
+
+export class FeatureToggleResponseDto {
+	@ApiProperty({ format: "uuid", example: "6ba7b810-9dad-11d1-80b4-00c04fd430c8" })
+	id!: string;
+
+	@ApiProperty({ example: "bug:same-day-restriction" })
+	key!: string;
+
+	@ApiProperty({ example: false })
+	enabled!: boolean;
+
+	@ApiPropertyOptional({
+		nullable: true,
+		example: "When enabled, disables API-side same-day appointment restrictions.",
+	})
+	description?: string | null;
+
+	@ApiPropertyOptional({ type: Object, additionalProperties: true, nullable: true, example: { rolloutPercentage: 50 } })
+	config?: Record<string, unknown> | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
+	createdAt!: string;
+}
+
+export class FeatureToggleListResponseDto {
+	@ApiProperty({ type: () => FeatureToggleResponseDto, isArray: true })
+	data!: FeatureToggleResponseDto[];
+}
+
+export class FeatureToggleDetailResponseDto {
+	@ApiProperty({ type: () => FeatureToggleResponseDto })
+	data!: FeatureToggleResponseDto;
+}
+
+export class UiTogglesDataResponseDto {
+	@ApiProperty({ example: false })
+	showFooterLogo!: boolean;
+}
+
+export class UiTogglesResponseDto {
+	@ApiProperty({ type: () => UiTogglesDataResponseDto })
+	data!: UiTogglesDataResponseDto;
+}
+
+export class AppointmentSummaryResponseDto {
+	@ApiProperty({ format: "date-time", example: "2026-06-15T09:30:00.000Z" })
+	scheduledAt!: string;
+
+	@ApiProperty({ enum: ["SCHEDULED", "CONFIRMED", "CANCELLED", "COMPLETED"], example: "CONFIRMED" })
+	status!: string;
+}
+
+export class AppointmentDateResponseDto {
+	@ApiProperty({ format: "date-time", example: "2026-06-15T09:30:00.000Z" })
+	scheduledAt!: string;
+}
+
+export class AppointmentRecordResponseDto {
+	@ApiProperty({ format: "uuid", example: "7c9e6679-7425-40de-944b-e07fc1f90ae7" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "c56a4180-65aa-42ec-a945-5fd21dec0538" })
+	patientId!: string;
+
+	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
+	doctorId!: string;
+
+	@ApiPropertyOptional({ format: "uuid", nullable: true, example: "de305d54-75b4-431b-adb2-eb6b9e546014" })
+	assistantId?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-06-15T09:30:00.000Z" })
+	scheduledAt!: string;
+
+	@ApiProperty({ enum: ["SCHEDULED", "CONFIRMED", "CANCELLED", "COMPLETED"], example: "CONFIRMED" })
+	status!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Follow-up consultation" })
+	notes?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
+	createdAt!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+}
+
+export class AppointmentStatusCountsResponseDto {
+	@ApiProperty({ example: 12 })
+	SCHEDULED!: number;
+
+	@ApiProperty({ example: 8 })
+	CONFIRMED!: number;
+
+	@ApiProperty({ example: 31 })
+	COMPLETED!: number;
+
+	@ApiProperty({ example: 4 })
+	CANCELLED!: number;
+}
+
+export class AppointmentStatsDataResponseDto {
+	@ApiProperty({ example: 5 })
+	todayCount!: number;
+
+	@ApiProperty({ example: 18 })
+	upcomingCount!: number;
+
+	@ApiProperty({ example: 31 })
+	completedCount!: number;
+
+	@ApiProperty({ example: 4 })
+	cancelledCount!: number;
+
+	@ApiProperty({ example: 55 })
+	totalCount!: number;
+
+	@ApiProperty({ type: () => AppointmentStatusCountsResponseDto })
+	byStatus!: AppointmentStatusCountsResponseDto;
+}
+
+export class AppointmentStatusHistoryItemResponseDto {
+	@ApiProperty({ format: "uuid", example: "6ba7b810-9dad-11d1-80b4-00c04fd430c8" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "7c9e6679-7425-40de-944b-e07fc1f90ae7" })
+	appointmentId!: string;
+
+	@ApiPropertyOptional({
+		enum: ["SCHEDULED", "CONFIRMED", "CANCELLED", "COMPLETED"],
+		nullable: true,
+		example: "SCHEDULED",
+	})
+	previousStatus?: string | null;
+
+	@ApiProperty({ enum: ["SCHEDULED", "CONFIRMED", "CANCELLED", "COMPLETED"], example: "CONFIRMED" })
+	newStatus!: string;
+
+	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	previousScheduledAt?: string | null;
+
+	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	newScheduledAt?: string | null;
+
+	@ApiProperty({ example: "90bb0a13-a7be-4f8b-b071-e07d1f7b8bc2" })
+	changedByKeycloakId!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:45:00.000Z" })
+	changedAt!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Jamie Lee" })
+	changedByName?: string | null;
+
+	@ApiPropertyOptional({ nullable: true, example: "assistant" })
+	changedByRole?: string | null;
+}
+
+export class PrescriptionItemResponseDto {
+	@ApiProperty({ format: "uuid", example: "6ba7b810-9dad-11d1-80b4-00c04fd430c8" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "7c9e6679-7425-40de-944b-e07fc1f90ae7" })
+	prescriptionId!: string;
+
+	@ApiProperty({ example: "Amoxicillin" })
+	medicationName!: string;
+
+	@ApiProperty({ example: "500 mg" })
+	dosage!: string;
+
+	@ApiProperty({ example: "Twice daily" })
+	frequency!: string;
+
+	@ApiProperty({ example: "7 days" })
+	duration!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Take after meals" })
+	instructions?: string | null;
+}
+
+export class PrescriptionRecordResponseDto {
+	@ApiProperty({ format: "uuid", example: "7c9e6679-7425-40de-944b-e07fc1f90ae7" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "8b43ab13-ef91-4b27-a0bb-0882e9bf65d6" })
+	appointmentId!: string;
+
+	@ApiProperty({ format: "uuid", example: "c56a4180-65aa-42ec-a945-5fd21dec0538" })
+	patientId!: string;
+
+	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
+	doctorId!: string;
+
+	@ApiPropertyOptional({ nullable: true, example: "Monitor blood pressure during this course." })
+	notes?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
+	createdAt!: string;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
+	updatedAt!: string;
+}
+
+export class ReviewRecordResponseDto {
+	@ApiProperty({ format: "uuid", example: "7c9e6679-7425-40de-944b-e07fc1f90ae7" })
+	id!: string;
+
+	@ApiProperty({ format: "uuid", example: "8b43ab13-ef91-4b27-a0bb-0882e9bf65d6" })
+	appointmentId!: string;
+
+	@ApiProperty({ format: "uuid", example: "c56a4180-65aa-42ec-a945-5fd21dec0538" })
+	patientId!: string;
+
+	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
+	doctorId!: string;
+
+	@ApiProperty({ minimum: 1, maximum: 5, example: 5 })
+	rating!: number;
+
+	@ApiPropertyOptional({ nullable: true, example: "Very clear explanation and punctual consultation." })
+	comment?: string | null;
+
+	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
+	createdAt!: string;
+}
+
+export class ReviewStatsResponseDto {
+	@ApiProperty({ example: 4.7 })
+	averageRating!: number;
+
+	@ApiProperty({ example: 18 })
+	totalReviews!: number;
+}

--- a/packages/api-common/src/ui-toggles.module.ts
+++ b/packages/api-common/src/ui-toggles.module.ts
@@ -1,8 +1,9 @@
 import { FEATURE_TOGGLE_KEYS } from "@clinic/shared-types";
 import { Controller, Get, Module } from "@nestjs/common";
-import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 
 import { PrismaService } from "./prisma.service";
+import { UiTogglesResponseDto } from "./swagger-response.dto";
 
 export interface UiToggles {
 	showFooterLogo: boolean;
@@ -16,6 +17,7 @@ export class UiTogglesController {
 
 	@Get()
 	@ApiOperation({ summary: "Get UI-related feature toggle states for the current portal" })
+	@ApiOkResponse({ type: UiTogglesResponseDto })
 	async list(): Promise<{ data: UiToggles }> {
 		const toggle = await this.prisma.featureToggle
 			.findUnique({ where: { key: FEATURE_TOGGLE_KEYS.SHOW_FOOTER_LOGO } })


### PR DESCRIPTION
Enhances API discoverability and developer experience by adding OpenAPI decorators across all endpoints in admin, assistant, doctor, and patient services.

Includes operation summaries, response type definitions, request body schemas with examples, and proper API tagging for all controllers. Creates reusable response DTOs in the common package to ensure consistent API contracts across services.

Improves documentation for health checks, SSE streams, file uploads, and feature toggle endpoints.