### PR TITLE
Adds support for multiple accepted client audiences

### DIFF
--- a/apps/api-patient/src/auth/keycloak-admin.service.ts
+++ b/apps/api-patient/src/auth/keycloak-admin.service.ts
@@ -36,7 +36,7 @@ export class KeycloakAdminService implements OnApplicationBootstrap {
 		this.realm = env.keycloak.realm;
 		this.clientId = env.keycloak.adminClientId;
 		this.clientSecret = env.keycloak.adminClientSecret;
-		this.patientClientId = env.keycloak.audience;
+		this.patientClientId = env.keycloak.clientId;
 		this.patientPortalUrl = readEnvOrDefault("PATIENT_PORTAL_URL", "http://localhost:5173");
 	}
 

--- a/packages/api-common/src/auth-module.ts
+++ b/packages/api-common/src/auth-module.ts
@@ -24,6 +24,9 @@ export interface JwtStrategyOptions {
  */
 export function createJwtStrategy(options: JwtStrategyOptions): new () => Strategy {
 	const label = options.errorLabel ?? options.requiredRole.charAt(0).toUpperCase() + options.requiredRole.slice(1);
+	const acceptedClients = Array.isArray(options.keycloak.audience)
+		? options.keycloak.audience
+		: [options.keycloak.audience];
 
 	@Injectable()
 	class JwtStrategy extends PassportStrategy(Strategy) {
@@ -37,12 +40,19 @@ export function createJwtStrategy(options: JwtStrategyOptions): new () => Strate
 					jwksUri: options.keycloak.jwksUri,
 				}),
 				issuer: options.keycloak.issuer,
-				audience: options.keycloak.audience,
 				algorithms: ["RS256"],
 			});
 		}
 
 		validate(payload: KeycloakTokenPayload): KeycloakTokenPayload {
+			const tokenAudiences = Array.isArray(payload.aud) ? payload.aud : payload.aud ? [payload.aud] : [];
+			const clientAllowed =
+				tokenAudiences.some(audience => acceptedClients.includes(audience)) ||
+				(payload.azp ? acceptedClients.includes(payload.azp) : false);
+			if (!clientAllowed) {
+				throw new UnauthorizedException("Token client not allowed");
+			}
+
 			const roles: string[] = payload.realm_access?.roles ?? [];
 			if (!roles.includes(options.requiredRole)) {
 				throw new UnauthorizedException(`${label} role required`);

--- a/packages/api-common/src/auth.ts
+++ b/packages/api-common/src/auth.ts
@@ -15,6 +15,8 @@ export interface KeycloakTokenPayload {
 	email: string;
 	given_name: string;
 	family_name: string;
+	aud?: string | string[];
+	azp?: string;
 	realm_access?: { roles: string[] };
 }
 

--- a/packages/api-common/src/keycloak.ts
+++ b/packages/api-common/src/keycloak.ts
@@ -3,7 +3,8 @@ import { parseHttpUrlEnv, readEnvOrDefault, requireEnv } from "./env";
 export interface KeycloakRuntimeConfig {
 	url: string;
 	realm: string;
-	audience: string;
+	clientId: string;
+	audience: string | string[];
 	adminClientId: string;
 	adminClientSecret: string;
 	issuer: string | string[];
@@ -43,10 +44,13 @@ export function loadKeycloakConfig(audienceEnvVar: string): KeycloakRuntimeConfi
 		}
 	}
 
+	const acceptedAudiences = [...new Set([audience, adminClientId])];
+
 	return {
 		url,
 		realm,
-		audience,
+		clientId: audience,
+		audience: acceptedAudiences.length === 1 ? acceptedAudiences[0] : acceptedAudiences,
 		adminClientId,
 		adminClientSecret,
 		issuer: issuers.length === 1 ? issuers[0] : issuers,


### PR DESCRIPTION
Enhances JWT token validation to accept tokens from multiple Keycloak clients by allowing audience configuration to be either a single string or an array of strings.

Validates both the 'aud' (audience) and 'azp' (authorized party) claims against the list of accepted clients, improving flexibility in multi-client authentication scenarios.

Updates the Keycloak configuration to automatically include both the primary client ID and admin client ID as accepted audiences, ensuring tokens from either client are properly validated.

Renames configuration property from 'audience' to 'clientId' for clarity while maintaining 'audience' for validation purposes.