### PR TITLE
Improves OpenAPI schema accuracy for nullable fields

### DIFF
--- a/apps/api-assistant/src/appointments/appointments.controller.ts
+++ b/apps/api-assistant/src/appointments/appointments.controller.ts
@@ -1,4 +1,4 @@
-import { EventsService, MailService } from "@clinic/api-common";
+import { EventsService, MailService, ASSISTANT_ID_API_PROPERTY } from "@clinic/api-common";
 import { ALLOWED_TRANSITIONS, AppointmentStatus } from "@clinic/shared-types";
 import {
 	Controller,
@@ -116,7 +116,7 @@ class AppointmentUserResponseDto {
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
 	updatedAt!: string;
 
-	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	@ApiPropertyOptional({ type: String, format: "date-time", nullable: true })
 	deletedAt?: string | null;
 }
 
@@ -127,16 +127,16 @@ class AppointmentPatientResponseDto {
 	@ApiProperty({ format: "uuid", example: "3f2504e0-4f89-11d3-9a0c-0305e82c3301" })
 	userId!: string;
 
-	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	@ApiPropertyOptional({ type: String, format: "date", nullable: true, example: "1990-01-15" })
 	dateOfBirth?: string | null;
 
-	@ApiPropertyOptional({ nullable: true, example: "+31 6 1234 5678" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "+31 6 1234 5678" })
 	phone?: string | null;
 
-	@ApiPropertyOptional({ nullable: true, example: "INS-2026-001" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "INS-2026-001" })
 	insuranceNumber?: string | null;
 
-	@ApiPropertyOptional({ nullable: true, example: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ..." })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ..." })
 	photo?: string | null;
 
 	@ApiProperty({ example: true })
@@ -156,10 +156,10 @@ class AppointmentDoctorResponseDto {
 	@ApiProperty({ format: "uuid", example: "550e8400-e29b-41d4-a716-446655440000" })
 	userId!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Cardiology" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Cardiology" })
 	specialization?: string | null;
 
-	@ApiPropertyOptional({ nullable: true, example: "MED-12345" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "MED-12345" })
 	licenseNumber?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
@@ -176,7 +176,7 @@ class AppointmentAssistantResponseDto {
 	@ApiProperty({ format: "uuid", example: "f47ac10b-58cc-4372-a567-0e02b2c3d479" })
 	userId!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Front Desk" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Front Desk" })
 	department?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
@@ -196,7 +196,7 @@ class AppointmentRecordResponseDto {
 	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
 	doctorId!: string;
 
-	@ApiPropertyOptional({ format: "uuid", nullable: true, example: "de305d54-75b4-431b-adb2-eb6b9e546014" })
+	@ApiPropertyOptional(ASSISTANT_ID_API_PROPERTY)
 	assistantId?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-06-15T09:30:00.000Z" })
@@ -205,7 +205,7 @@ class AppointmentRecordResponseDto {
 	@ApiProperty({ enum: AppointmentStatusEnum, example: AppointmentStatusEnum.SCHEDULED })
 	status!: AppointmentStatus;
 
-	@ApiPropertyOptional({ nullable: true, example: "Follow-up consultation" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Follow-up consultation" })
 	notes?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
@@ -267,16 +267,16 @@ class AppointmentStatusHistoryItemResponseDto {
 	@ApiProperty({ format: "uuid", example: "7c9e6679-7425-40de-944b-e07fc1f90ae7" })
 	appointmentId!: string;
 
-	@ApiPropertyOptional({ enum: AppointmentStatusEnum, nullable: true })
+	@ApiPropertyOptional({ type: String, enum: AppointmentStatusEnum, nullable: true })
 	previousStatus?: AppointmentStatus | null;
 
 	@ApiProperty({ enum: AppointmentStatusEnum, example: AppointmentStatusEnum.CONFIRMED })
 	newStatus!: AppointmentStatus;
 
-	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	@ApiPropertyOptional({ type: String, format: "date-time", nullable: true })
 	previousScheduledAt?: string | null;
 
-	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	@ApiPropertyOptional({ type: String, format: "date-time", nullable: true })
 	newScheduledAt?: string | null;
 
 	@ApiProperty({ example: "90bb0a13-a7be-4f8b-b071-e07d1f7b8bc2" })
@@ -285,10 +285,15 @@ class AppointmentStatusHistoryItemResponseDto {
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:45:00.000Z" })
 	changedAt!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Jamie Lee" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Jamie Lee" })
 	changedByName?: string | null;
 
-	@ApiPropertyOptional({ enum: ["patient", "doctor", "assistant", "admin"], nullable: true, example: "assistant" })
+	@ApiPropertyOptional({
+		type: String,
+		enum: ["patient", "doctor", "assistant", "admin"],
+		nullable: true,
+		example: "assistant",
+	})
 	changedByRole?: string | null;
 }
 

--- a/apps/api-doctor/src/availability/availability.controller.ts
+++ b/apps/api-doctor/src/availability/availability.controller.ts
@@ -57,7 +57,7 @@ class DoctorUnavailabilityResponseDto {
 	@ApiProperty({ format: "date-time", example: "2026-06-20T12:00:00.000Z" })
 	endDate!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Medical conference" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Medical conference" })
 	reason?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })

--- a/apps/api-doctor/src/patients/patients.controller.ts
+++ b/apps/api-doctor/src/patients/patients.controller.ts
@@ -1,4 +1,9 @@
-import { DoctorCoreResponseDto, PatientCoreResponseDto, UserCoreResponseDto } from "@clinic/api-common";
+import {
+	DoctorCoreResponseDto,
+	PatientCoreResponseDto,
+	UserCoreResponseDto,
+	ASSISTANT_ID_API_PROPERTY,
+} from "@clinic/api-common";
 import {
 	Controller,
 	Get,
@@ -35,7 +40,7 @@ class DoctorPatientAppointmentResponseDto {
 	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
 	doctorId!: string;
 
-	@ApiPropertyOptional({ format: "uuid", nullable: true, example: "de305d54-75b4-431b-adb2-eb6b9e546014" })
+	@ApiPropertyOptional(ASSISTANT_ID_API_PROPERTY)
 	assistantId?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-06-15T09:30:00.000Z" })
@@ -44,7 +49,7 @@ class DoctorPatientAppointmentResponseDto {
 	@ApiProperty({ enum: ["SCHEDULED", "CONFIRMED", "CANCELLED", "COMPLETED"], example: "COMPLETED" })
 	status!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Follow-up consultation" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Follow-up consultation" })
 	notes?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })

--- a/apps/api-patient/src/doctors/doctors.controller.ts
+++ b/apps/api-patient/src/doctors/doctors.controller.ts
@@ -60,7 +60,7 @@ class DoctorDirectoryItemResponseDto {
 	@ApiProperty({ format: "uuid", example: "550e8400-e29b-41d4-a716-446655440000" })
 	userId!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Cardiology" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Cardiology" })
 	specialization?: string | null;
 
 	@ApiProperty({ example: "Alex" })
@@ -69,7 +69,7 @@ class DoctorDirectoryItemResponseDto {
 	@ApiProperty({ example: "Morgan" })
 	lastName!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: 4.7 })
+	@ApiPropertyOptional({ type: Number, nullable: true, example: 4.7 })
 	averageRating?: number | null;
 
 	@ApiProperty({ example: 18 })

--- a/apps/assistant-portal/src/pages/PatientDetailPage.tsx
+++ b/apps/assistant-portal/src/pages/PatientDetailPage.tsx
@@ -1,3 +1,4 @@
+import { formatDateOnly } from "@clinic/portal-common";
 import { Upload } from "lucide-react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
@@ -219,7 +220,7 @@ function PatientInfoCard({
 				<InfoRow label="Phone" value={patient.patient?.phone ?? "—"} testId="patient-info-phone" />
 				<InfoRow
 					label="Date of birth"
-					value={patient.patient?.dateOfBirth ? new Date(patient.patient.dateOfBirth).toLocaleDateString("en-NL") : "—"}
+					value={patient.patient?.dateOfBirth ? formatDateOnly(patient.patient.dateOfBirth, "en-NL") : "—"}
 					testId="patient-info-date-of-birth"
 				/>
 				<InfoRow label="Insurance #" value={patient.patient?.insuranceNumber ?? "—"} testId="patient-info-insurance" />

--- a/apps/doctor-portal/src/pages/PatientDetailPage.tsx
+++ b/apps/doctor-portal/src/pages/PatientDetailPage.tsx
@@ -1,3 +1,4 @@
+import { formatDateOnly } from "@clinic/portal-common";
 import type { Patient, Appointment } from "@clinic/shared-types";
 import React, { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
@@ -69,9 +70,7 @@ export default function PatientDetailPage(): React.ReactElement {
 							<Row label="Phone" value={patient.patient?.phone ?? "—"} />
 							<Row
 								label="Date of birth"
-								value={
-									patient.patient?.dateOfBirth ? new Date(patient.patient.dateOfBirth).toLocaleDateString("en-NL") : "—"
-								}
+								value={patient.patient?.dateOfBirth ? formatDateOnly(patient.patient.dateOfBirth, "en-NL") : "—"}
 							/>
 							<Row label="Insurance #" value={patient.patient?.insuranceNumber ?? "—"} />
 						</dl>

--- a/packages/api-common/src/bootstrap.ts
+++ b/packages/api-common/src/bootstrap.ts
@@ -5,6 +5,7 @@ import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import compression from "compression";
 import helmet from "helmet";
 
+import { DateOnlyResponseInterceptor } from "./date-only-response.interceptor";
 import { PrismaExceptionFilter } from "./prisma-exception.filter";
 
 export interface BootstrapApiOptions {
@@ -41,6 +42,9 @@ export async function bootstrapApi(options: BootstrapApiOptions): Promise<void> 
 			transform: true,
 		})
 	);
+	// Normalizes `dateOfBirth` in JSON responses to `YYYY-MM-DD` so the payload
+	// matches the OpenAPI `format: "date"` contract (Prisma returns it as Date).
+	app.useGlobalInterceptors(new DateOnlyResponseInterceptor());
 
 	if (options.enableSwagger) {
 		const config = new DocumentBuilder()

--- a/packages/api-common/src/date-only-response.interceptor.ts
+++ b/packages/api-common/src/date-only-response.interceptor.ts
@@ -1,0 +1,85 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nestjs/common";
+import { map, Observable } from "rxjs";
+
+/**
+ * Normalizes any `dateOfBirth` field anywhere in a JSON response payload to a
+ * `YYYY-MM-DD` string. This exists because Prisma returns `dateOfBirth` as a
+ * full `Date`/ISO timestamp, but our OpenAPI contract documents it as a
+ * `format: "date"` (date-only) string. Applied globally in `bootstrapApi`.
+ *
+ * Behaviour notes:
+ * - Only fields literally named `dateOfBirth` are rewritten. Other date fields
+ *   (e.g. `createdAt`, `scheduledAt`) remain `date-time`.
+ * - The walker is non-mutating: it returns the original object reference when
+ *   nothing changes, and a shallow-cloned copy when a field is rewritten. This
+ *   keeps shared/cached upstream references safe.
+ * - `Date`, `Buffer`, typed arrays, primitives, and already-visited objects
+ *   are returned as-is.
+ */
+function toDateOnlyString(value: Date | string): string {
+	if (value instanceof Date) {
+		return value.toISOString().slice(0, 10);
+	}
+	const datePrefix = /^(\d{4}-\d{2}-\d{2})(?:$|T)/.exec(value)?.[1];
+	if (datePrefix) {
+		return datePrefix;
+	}
+	const parsed = new Date(value);
+	return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString().slice(0, 10);
+}
+
+function normalizeArray(value: unknown[], visited: WeakSet<object>): unknown {
+	let changed = false;
+	const next: unknown[] = new Array(value.length);
+	for (let i = 0; i < value.length; i += 1) {
+		const item: unknown = value[i];
+		const normalized = normalizeDateOnlyFields(item, visited);
+		if (normalized !== item) {
+			changed = true;
+		}
+		next[i] = normalized;
+	}
+	return changed ? next : value;
+}
+
+function normalizeObject(value: object, visited: WeakSet<object>): unknown {
+	let changed = false;
+	const next: Record<string, unknown> = {};
+	for (const [key, nested] of Object.entries(value)) {
+		const normalized =
+			key === "dateOfBirth" && (nested instanceof Date || typeof nested === "string")
+				? toDateOnlyString(nested)
+				: normalizeDateOnlyFields(nested, visited);
+		next[key] = normalized;
+		if (normalized !== nested) {
+			changed = true;
+		}
+	}
+	if (!changed) {
+		return value;
+	}
+	const proto = Object.getPrototypeOf(value) as object | null;
+	const cloned = proto && proto !== Object.prototype ? Object.create(proto) : {};
+	return Object.assign(cloned, next);
+}
+
+function normalizeDateOnlyFields(value: unknown, visited: WeakSet<object>): unknown {
+	if (value === null || typeof value !== "object") {
+		return value;
+	}
+	if (value instanceof Date || Buffer.isBuffer(value) || ArrayBuffer.isView(value)) {
+		return value;
+	}
+	if (visited.has(value)) {
+		return value;
+	}
+	visited.add(value);
+	return Array.isArray(value) ? normalizeArray(value, visited) : normalizeObject(value, visited);
+}
+
+@Injectable()
+export class DateOnlyResponseInterceptor implements NestInterceptor {
+	intercept(_context: ExecutionContext, next: CallHandler): Observable<unknown> {
+		return next.handle().pipe(map(value => normalizeDateOnlyFields(value, new WeakSet<object>())));
+	}
+}

--- a/packages/api-common/src/swagger-response.dto.ts
+++ b/packages/api-common/src/swagger-response.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 
+/** Shared Swagger metadata for the nullable `assistantId` UUID field. */
+export const ASSISTANT_ID_API_PROPERTY = {
+	type: String,
+	format: "uuid",
+	nullable: true,
+	example: "de305d54-75b4-431b-adb2-eb6b9e546014",
+} as const;
+
 export class UserNameResponseDto {
 	@ApiProperty({ example: "Alex" })
 	firstName!: string;
@@ -38,7 +46,7 @@ export class UserCoreResponseDto {
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
 	updatedAt!: string;
 
-	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	@ApiPropertyOptional({ type: String, format: "date-time", nullable: true })
 	deletedAt?: string | null;
 }
 
@@ -49,16 +57,16 @@ export class PatientCoreResponseDto {
 	@ApiProperty({ format: "uuid", example: "3f2504e0-4f89-11d3-9a0c-0305e82c3301" })
 	userId!: string;
 
-	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	@ApiPropertyOptional({ type: String, format: "date", nullable: true, example: "1990-01-15" })
 	dateOfBirth?: string | null;
 
-	@ApiPropertyOptional({ nullable: true, example: "+31 6 1234 5678" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "+31 6 1234 5678" })
 	phone?: string | null;
 
-	@ApiPropertyOptional({ nullable: true, example: "INS-2026-001" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "INS-2026-001" })
 	insuranceNumber?: string | null;
 
-	@ApiPropertyOptional({ nullable: true, example: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ..." })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQ..." })
 	photo?: string | null;
 
 	@ApiProperty({ example: true })
@@ -75,10 +83,10 @@ export class DoctorCoreResponseDto {
 	@ApiProperty({ format: "uuid", example: "550e8400-e29b-41d4-a716-446655440000" })
 	userId!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Cardiology" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Cardiology" })
 	specialization?: string | null;
 
-	@ApiPropertyOptional({ nullable: true, example: "MED-12345" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "MED-12345" })
 	licenseNumber?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
@@ -92,7 +100,7 @@ export class AssistantCoreResponseDto {
 	@ApiProperty({ format: "uuid", example: "f47ac10b-58cc-4372-a567-0e02b2c3d479" })
 	userId!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Front Desk" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Front Desk" })
 	department?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:30:00.000Z" })
@@ -126,6 +134,7 @@ export class FeatureToggleResponseDto {
 	enabled!: boolean;
 
 	@ApiPropertyOptional({
+		type: String,
 		nullable: true,
 		example: "When enabled, disables API-side same-day appointment restrictions.",
 	})
@@ -184,7 +193,7 @@ export class AppointmentRecordResponseDto {
 	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
 	doctorId!: string;
 
-	@ApiPropertyOptional({ format: "uuid", nullable: true, example: "de305d54-75b4-431b-adb2-eb6b9e546014" })
+	@ApiPropertyOptional(ASSISTANT_ID_API_PROPERTY)
 	assistantId?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-06-15T09:30:00.000Z" })
@@ -193,7 +202,7 @@ export class AppointmentRecordResponseDto {
 	@ApiProperty({ enum: ["SCHEDULED", "CONFIRMED", "CANCELLED", "COMPLETED"], example: "CONFIRMED" })
 	status!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Follow-up consultation" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Follow-up consultation" })
 	notes?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
@@ -245,6 +254,7 @@ export class AppointmentStatusHistoryItemResponseDto {
 	appointmentId!: string;
 
 	@ApiPropertyOptional({
+		type: String,
 		enum: ["SCHEDULED", "CONFIRMED", "CANCELLED", "COMPLETED"],
 		nullable: true,
 		example: "SCHEDULED",
@@ -254,10 +264,10 @@ export class AppointmentStatusHistoryItemResponseDto {
 	@ApiProperty({ enum: ["SCHEDULED", "CONFIRMED", "CANCELLED", "COMPLETED"], example: "CONFIRMED" })
 	newStatus!: string;
 
-	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	@ApiPropertyOptional({ type: String, format: "date-time", nullable: true })
 	previousScheduledAt?: string | null;
 
-	@ApiPropertyOptional({ format: "date-time", nullable: true })
+	@ApiPropertyOptional({ type: String, format: "date-time", nullable: true })
 	newScheduledAt?: string | null;
 
 	@ApiProperty({ example: "90bb0a13-a7be-4f8b-b071-e07d1f7b8bc2" })
@@ -266,10 +276,10 @@ export class AppointmentStatusHistoryItemResponseDto {
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:45:00.000Z" })
 	changedAt!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Jamie Lee" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Jamie Lee" })
 	changedByName?: string | null;
 
-	@ApiPropertyOptional({ nullable: true, example: "assistant" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "assistant" })
 	changedByRole?: string | null;
 }
 
@@ -292,7 +302,7 @@ export class PrescriptionItemResponseDto {
 	@ApiProperty({ example: "7 days" })
 	duration!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Take after meals" })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Take after meals" })
 	instructions?: string | null;
 }
 
@@ -309,7 +319,7 @@ export class PrescriptionRecordResponseDto {
 	@ApiProperty({ format: "uuid", example: "7d444840-9dc0-11d1-b245-5ffdce74fad2" })
 	doctorId!: string;
 
-	@ApiPropertyOptional({ nullable: true, example: "Monitor blood pressure during this course." })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Monitor blood pressure during this course." })
 	notes?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })
@@ -335,7 +345,7 @@ export class ReviewRecordResponseDto {
 	@ApiProperty({ minimum: 1, maximum: 5, example: 5 })
 	rating!: number;
 
-	@ApiPropertyOptional({ nullable: true, example: "Very clear explanation and punctual consultation." })
+	@ApiPropertyOptional({ type: String, nullable: true, example: "Very clear explanation and punctual consultation." })
 	comment?: string | null;
 
 	@ApiProperty({ format: "date-time", example: "2026-05-28T09:00:00.000Z" })

--- a/packages/portal-common/src/date-only.ts
+++ b/packages/portal-common/src/date-only.ts
@@ -1,0 +1,12 @@
+/**
+ * Formats a `YYYY-MM-DD` (or ISO date-time) string for display, anchored to
+ * UTC so the rendered day never shifts by browser timezone. Returns an empty
+ * string for nullish or unparseable input — call sites should provide their
+ * own placeholder (e.g. `"—"`) if needed.
+ */
+export function formatDateOnly(value: string | null | undefined, locale?: string | string[]): string {
+	if (!value) return "";
+	const match = /^(\d{4})-(\d{2})-(\d{2})(?:$|T)/.exec(value);
+	if (!match) return "";
+	return new Date(`${match[1]}-${match[2]}-${match[3]}T00:00:00.000Z`).toLocaleDateString(locale, { timeZone: "UTC" });
+}

--- a/packages/portal-common/src/index.ts
+++ b/packages/portal-common/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./api";
 export * from "./config";
+export * from "./date-only";
 export * from "./keycloak";
 export * from "./portal-footer";
 export * from "./role-mismatch-screen";


### PR DESCRIPTION
Adds explicit `type` property to all `@ApiPropertyOptional` decorators with nullable fields to ensure correct OpenAPI schema generation. Without explicit typing, Swagger may infer incorrect types for nullable properties.

Introduces `ASSISTANT_ID_API_PROPERTY` constant to standardize nullable UUID field documentation across multiple controllers.

Adds `DateOnlyResponseInterceptor` to normalize `dateOfBirth` fields to ISO date format (`YYYY-MM-DD`) in API responses, ensuring consistency with OpenAPI `format: "date"` specification.

Updates frontend date formatting to use new `formatDateOnly` utility for standardized date-only display.