### PR TITLE
fix: remove onLoad check-sso from keycloak init (v26 redirect loop)

### DIFF
--- a/apps/assistant-portal/src/main.tsx
+++ b/apps/assistant-portal/src/main.tsx
@@ -9,7 +9,6 @@ import keycloak from "./keycloak";
 
 void keycloak
 	.init({
-		onLoad: "check-sso",
 		pkceMethod: "S256",
 		checkLoginIframe: false,
 	})
@@ -25,6 +24,7 @@ void keycloak
 			</React.StrictMode>
 		);
 	})
-	.catch(() => {
+	.catch((err: unknown) => {
+		console.error("[keycloak] init failed", err);
 		createRoot(document.getElementById("root")!).render(<AuthServiceUnavailableScreen />);
 	});

--- a/apps/patient-portal/src/main.tsx
+++ b/apps/patient-portal/src/main.tsx
@@ -9,7 +9,6 @@ import keycloak from "./keycloak";
 
 void keycloak
 	.init({
-		onLoad: "check-sso",
 		pkceMethod: "S256",
 		checkLoginIframe: false,
 	})
@@ -29,7 +28,8 @@ void keycloak
 			</StrictMode>
 		);
 	})
-	.catch(() => {
+	.catch((err: unknown) => {
+		console.error("[keycloak] init failed", err);
 		createRoot(document.getElementById("root")!).render(
 			<StrictMode>
 				<AuthServiceUnavailableScreen />

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,188 @@
+# Demo deployment for demo-sparta.mooo.com
+# Port conflicts: 3001→13001 (stock-advisor), 8080→18180 (searxng)
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: clinic-postgres
+    environment:
+      POSTGRES_USER: clinic
+      POSTGRES_PASSWORD: clinic_secret
+      POSTGRES_DB: clinic_db
+    ports:
+      - "15432:5432"
+    volumes:
+      - clinic_postgres_data:/var/lib/postgresql/data
+      - ./infra/postgres:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U clinic -d clinic_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:24.0.1
+    container_name: clinic-keycloak
+    command: start-dev --import-realm
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin_secret
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres:5432/clinic_db
+      KC_DB_USERNAME: clinic
+      KC_DB_PASSWORD: clinic_secret
+      KC_DB_SCHEMA: keycloak
+      KC_HEALTH_ENABLED: "true"
+      KC_HTTP_PORT: "8080"
+      KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_HTTPS: "false"
+      KC_HOSTNAME_STRICT_BACKCHANNEL: "false"
+    ports:
+      - "18180:8080"
+    volumes:
+      - ./infra/keycloak:/opt/keycloak/data/import
+      - ./infra/keycloak/themes:/opt/keycloak/themes
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.0\r\n\r\n' >&3 && cat <&3 | grep -q 'status' && echo healthy || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 20
+      start_period: 90s
+
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: clinic-mailpit
+    ports:
+      - "11025:1025"
+      - "18025:8025"
+    environment:
+      MP_MAX_MESSAGES: 500
+      MP_SMTP_AUTH_ACCEPT_ANY: "true"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "true"
+
+  db-init:
+    container_name: clinic-db-init
+    build:
+      context: ./
+      dockerfile: infra/docker/Dockerfile.db-init
+    environment:
+      DATABASE_URL: "postgresql://clinic:clinic_secret@postgres:5432/clinic_db"
+      KEYCLOAK_URL: "http://keycloak:8080"
+      KEYCLOAK_REALM: clinic
+      KEYCLOAK_ADMIN_USER: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin_secret
+      SEED_STAFF_PASSWORD: "Clinic1234!"
+      SEED_PATIENT_PASSWORD: "Patient1234!"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
+    restart: "no"
+
+  api-patient:
+    container_name: clinic-api-patient
+    build:
+      context: ./
+      dockerfile: infra/docker/Dockerfile.api
+      args:
+        APP_NAME: api-patient
+    ports:
+      - "13001:3001"
+    environment:
+      PORT: "3001"
+      NODE_ENV: production
+      ENABLE_SWAGGER: "true"
+      DATABASE_URL: "postgresql://clinic:clinic_secret@postgres:5432/clinic_db"
+      KEYCLOAK_URL: "http://keycloak:8080"
+      KEYCLOAK_PUBLIC_URL: "http://demo-sparta.mooo.com:18180"
+      KEYCLOAK_REALM: clinic
+      KEYCLOAK_PATIENT_CLIENT_ID: patient-portal-client
+      KEYCLOAK_ADMIN_CLIENT_ID: api-service-client
+      KEYCLOAK_ADMIN_CLIENT_SECRET: api_service_secret_change_in_prod
+      API_PATIENT_CORS_ORIGINS: "http://demo-sparta.mooo.com:15173"
+      PATIENT_PORTAL_URL: "http://demo-sparta.mooo.com:15173"
+      SMTP_HOST: mailpit
+      SMTP_PORT: "1025"
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3001/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  api-assistant:
+    container_name: clinic-api-assistant
+    build:
+      context: ./
+      dockerfile: infra/docker/Dockerfile.api
+      args:
+        APP_NAME: api-assistant
+    ports:
+      - "13003:3003"
+    environment:
+      PORT: "3003"
+      NODE_ENV: production
+      ENABLE_SWAGGER: "true"
+      DATABASE_URL: "postgresql://clinic:clinic_secret@postgres:5432/clinic_db"
+      KEYCLOAK_URL: "http://keycloak:8080"
+      KEYCLOAK_PUBLIC_URL: "http://demo-sparta.mooo.com:18180"
+      KEYCLOAK_REALM: clinic
+      KEYCLOAK_ASSISTANT_CLIENT_ID: assistant-portal-client
+      KEYCLOAK_ADMIN_CLIENT_ID: api-service-client
+      KEYCLOAK_ADMIN_CLIENT_SECRET: api_service_secret_change_in_prod
+      API_ASSISTANT_CORS_ORIGINS: "http://demo-sparta.mooo.com:15175"
+      SMTP_HOST: mailpit
+      SMTP_PORT: "1025"
+    depends_on:
+      db-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3003/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  patient-portal:
+    container_name: clinic-patient-portal
+    build:
+      context: ./
+      dockerfile: infra/docker/Dockerfile.frontend
+      args:
+        APP_NAME: patient-portal
+        VITE_PATIENT_API_BASE_URL: "http://demo-sparta.mooo.com:13001/api"
+        VITE_KEYCLOAK_URL: "http://demo-sparta.mooo.com:18180"
+        VITE_KEYCLOAK_REALM: clinic
+        VITE_PATIENT_KEYCLOAK_CLIENT_ID: patient-portal-client
+    ports:
+      - "15173:80"
+    depends_on:
+      api-patient:
+        condition: service_healthy
+
+  assistant-portal:
+    container_name: clinic-assistant-portal
+    build:
+      context: ./
+      dockerfile: infra/docker/Dockerfile.frontend
+      args:
+        APP_NAME: assistant-portal
+        VITE_ASSISTANT_API_BASE_URL: "http://demo-sparta.mooo.com:13003/api"
+        VITE_KEYCLOAK_URL: "http://demo-sparta.mooo.com:18180"
+        VITE_KEYCLOAK_REALM: clinic
+        VITE_ASSISTANT_KEYCLOAK_CLIENT_ID: assistant-portal-client
+    ports:
+      - "15175:80"
+    depends_on:
+      api-assistant:
+        condition: service_healthy
+
+volumes:
+  clinic_postgres_data:

--- a/infra/keycloak/clinic-realm.json
+++ b/infra/keycloak/clinic-realm.json
@@ -1,6 +1,7 @@
 {
 	"realm": "clinic",
 	"enabled": true,
+	"sslRequired": "none",
 	"displayName": "Clinic Portal",
 	"registrationAllowed": false,
 	"registrationEmailAsUsername": true,
@@ -35,8 +36,8 @@
 			"publicClient": true,
 			"standardFlowEnabled": true,
 			"directAccessGrantsEnabled": false,
-			"redirectUris": ["http://localhost:5173/*"],
-			"webOrigins": ["http://localhost:5173"],
+			"redirectUris": ["http://localhost:5173/*", "http://demo-sparta.mooo.com:15173/*"],
+			"webOrigins": ["http://localhost:5173", "http://demo-sparta.mooo.com:15173"],
 			"attributes": {
 				"pkce.code.challenge.method": "S256",
 				"login_theme": "patient-theme"
@@ -125,8 +126,8 @@
 			"publicClient": true,
 			"standardFlowEnabled": true,
 			"directAccessGrantsEnabled": false,
-			"redirectUris": ["http://localhost:5175/*"],
-			"webOrigins": ["http://localhost:5175"],
+			"redirectUris": ["http://localhost:5175/*", "http://demo-sparta.mooo.com:15175/*"],
+			"webOrigins": ["http://localhost:5175", "http://demo-sparta.mooo.com:15175"],
 			"attributes": {
 				"pkce.code.challenge.method": "S256",
 				"login_theme": "assistant-theme"


### PR DESCRIPTION
Verwijder onLoad check-sso uit Keycloak init (v26 redirect loop met HTTP). Zonder onLoad start app altijd, ProtectedRoute redirect naar /login.